### PR TITLE
SPDBCSC-256: Added services for validating JWT tokens from BCSC.

### DIFF
--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/configuration/EcrcProperties.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/configuration/EcrcProperties.java
@@ -48,6 +48,7 @@ public class EcrcProperties {
 	private String oauthTokenPath;
 	private String oauthUserinfoPath;
 	private String oauthAuthorizePath;
+	private String oauthWellKnown;
 
 	// JWT properties
 	private String jwtHeader;
@@ -297,5 +298,13 @@ public class EcrcProperties {
 	public String getOauthAuthorizePath() { return oauthAuthorizePath; }
 
 	public void setOauthAuthorizePath(String oauthAuthorizePath) { this.oauthAuthorizePath = oauthAuthorizePath; }
+	
+	public String getOauthWellKnown() {
+		return oauthWellKnown;
+	}
+
+	public void setOauthWellKnown(String oauthWellKnown) {
+		this.oauthWellKnown = oauthWellKnown;
+	}
 
 }

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/configuration/WebSecurityConfig.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/configuration/WebSecurityConfig.java
@@ -10,8 +10,8 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 
-@EnableWebSecurity
-@Configuration
+//@EnableWebSecurity
+//@Configuration
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Autowired

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/configuration/WebSecurityConfig.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/configuration/WebSecurityConfig.java
@@ -10,8 +10,8 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 
-//@EnableWebSecurity
-//@Configuration
+@EnableWebSecurity
+@Configuration
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Autowired

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/controller/OauthController.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/controller/OauthController.java
@@ -99,6 +99,8 @@ public class OauthController {
 			throw new OauthServiceException("Error generating client token. ", e);
 		}
 		
+		// TODO - validate tokens received from BCSC. 
+		
 		// Fetch corresponding Userinfo from the IdP server.  
 		JSONObject userInfo = oauthServices.getUserInfo((BearerAccessToken)token.toSuccessResponse().getTokens().getAccessToken());
 		

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/model/OIDCConfiguration.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/model/OIDCConfiguration.java
@@ -238,3 +238,4 @@ public class OIDCConfiguration {
 	}
 
 }
+

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/model/OIDCConfiguration.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/model/OIDCConfiguration.java
@@ -1,0 +1,240 @@
+package ca.bc.gov.open.ecrc.model;
+
+import java.util.List;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * OIDC Configuration - Used for serializing https://[myOauthServer]/.well-known/openid-configuration response. 
+ * 
+ * @author shaunmillargov
+ *
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "response_types_supported", "request_parameter_supported", "request_uri_parameter_supported",
+		"claims_parameter_supported", "introspection_endpoint", "grant_types_supported", "revocation_endpoint",
+		"scopes_supported", "issuer", "authorization_endpoint", "userinfo_endpoint",
+		"token_endpoint_auth_signing_alg_values_supported", "userinfo_signing_alg_values_supported", "jwks_uri",
+		"subject_types_supported", "id_token_signing_alg_values_supported", "token_endpoint_auth_methods_supported",
+		"token_endpoint" })
+public class OIDCConfiguration {
+
+	@JsonProperty("response_types_supported")
+	private List<String> responseTypesSupported = null;
+	@JsonProperty("request_parameter_supported")
+	private Boolean requestParameterSupported;
+	@JsonProperty("request_uri_parameter_supported")
+	private Boolean requestUriParameterSupported;
+	@JsonProperty("claims_parameter_supported")
+	private Boolean claimsParameterSupported;
+	@JsonProperty("introspection_endpoint")
+	private String introspectionEndpoint;
+	@JsonProperty("grant_types_supported")
+	private List<String> grantTypesSupported = null;
+	@JsonProperty("revocation_endpoint")
+	private String revocationEndpoint;
+	@JsonProperty("scopes_supported")
+	private List<String> scopesSupported = null;
+	@JsonProperty("issuer")
+	private String issuer;
+	@JsonProperty("authorization_endpoint")
+	private String authorizationEndpoint;
+	@JsonProperty("userinfo_endpoint")
+	private String userinfoEndpoint;
+	@JsonProperty("token_endpoint_auth_signing_alg_values_supported")
+	private List<String> tokenEndpointAuthSigningAlgValuesSupported = null;
+	@JsonProperty("userinfo_signing_alg_values_supported")
+	private List<String> userinfoSigningAlgValuesSupported = null;
+	@JsonProperty("jwks_uri")
+	private String jwksUri;
+	@JsonProperty("subject_types_supported")
+	private List<String> subjectTypesSupported = null;
+	@JsonProperty("id_token_signing_alg_values_supported")
+	private List<String> idTokenSigningAlgValuesSupported = null;
+	@JsonProperty("token_endpoint_auth_methods_supported")
+	private List<String> tokenEndpointAuthMethodsSupported = null;
+	@JsonProperty("token_endpoint")
+	private String tokenEndpoint;
+
+	@JsonProperty("response_types_supported")
+	public List<String> getResponseTypesSupported() {
+		return responseTypesSupported;
+	}
+
+	@JsonProperty("response_types_supported")
+	public void setResponseTypesSupported(List<String> responseTypesSupported) {
+		this.responseTypesSupported = responseTypesSupported;
+	}
+
+	@JsonProperty("request_parameter_supported")
+	public Boolean getRequestParameterSupported() {
+		return requestParameterSupported;
+	}
+
+	@JsonProperty("request_parameter_supported")
+	public void setRequestParameterSupported(Boolean requestParameterSupported) {
+		this.requestParameterSupported = requestParameterSupported;
+	}
+
+	@JsonProperty("request_uri_parameter_supported")
+	public Boolean getRequestUriParameterSupported() {
+		return requestUriParameterSupported;
+	}
+
+	@JsonProperty("request_uri_parameter_supported")
+	public void setRequestUriParameterSupported(Boolean requestUriParameterSupported) {
+		this.requestUriParameterSupported = requestUriParameterSupported;
+	}
+
+	@JsonProperty("claims_parameter_supported")
+	public Boolean getClaimsParameterSupported() {
+		return claimsParameterSupported;
+	}
+
+	@JsonProperty("claims_parameter_supported")
+	public void setClaimsParameterSupported(Boolean claimsParameterSupported) {
+		this.claimsParameterSupported = claimsParameterSupported;
+	}
+
+	@JsonProperty("introspection_endpoint")
+	public String getIntrospectionEndpoint() {
+		return introspectionEndpoint;
+	}
+
+	@JsonProperty("introspection_endpoint")
+	public void setIntrospectionEndpoint(String introspectionEndpoint) {
+		this.introspectionEndpoint = introspectionEndpoint;
+	}
+
+	@JsonProperty("grant_types_supported")
+	public List<String> getGrantTypesSupported() {
+		return grantTypesSupported;
+	}
+
+	@JsonProperty("grant_types_supported")
+	public void setGrantTypesSupported(List<String> grantTypesSupported) {
+		this.grantTypesSupported = grantTypesSupported;
+	}
+
+	@JsonProperty("revocation_endpoint")
+	public String getRevocationEndpoint() {
+		return revocationEndpoint;
+	}
+
+	@JsonProperty("revocation_endpoint")
+	public void setRevocationEndpoint(String revocationEndpoint) {
+		this.revocationEndpoint = revocationEndpoint;
+	}
+
+	@JsonProperty("scopes_supported")
+	public List<String> getScopesSupported() {
+		return scopesSupported;
+	}
+
+	@JsonProperty("scopes_supported")
+	public void setScopesSupported(List<String> scopesSupported) {
+		this.scopesSupported = scopesSupported;
+	}
+
+	@JsonProperty("issuer")
+	public String getIssuer() {
+		return issuer;
+	}
+
+	@JsonProperty("issuer")
+	public void setIssuer(String issuer) {
+		this.issuer = issuer;
+	}
+
+	@JsonProperty("authorization_endpoint")
+	public String getAuthorizationEndpoint() {
+		return authorizationEndpoint;
+	}
+
+	@JsonProperty("authorization_endpoint")
+	public void setAuthorizationEndpoint(String authorizationEndpoint) {
+		this.authorizationEndpoint = authorizationEndpoint;
+	}
+
+	@JsonProperty("userinfo_endpoint")
+	public String getUserinfoEndpoint() {
+		return userinfoEndpoint;
+	}
+
+	@JsonProperty("userinfo_endpoint")
+	public void setUserinfoEndpoint(String userinfoEndpoint) {
+		this.userinfoEndpoint = userinfoEndpoint;
+	}
+
+	@JsonProperty("token_endpoint_auth_signing_alg_values_supported")
+	public List<String> getTokenEndpointAuthSigningAlgValuesSupported() {
+		return tokenEndpointAuthSigningAlgValuesSupported;
+	}
+
+	@JsonProperty("token_endpoint_auth_signing_alg_values_supported")
+	public void setTokenEndpointAuthSigningAlgValuesSupported(List<String> tokenEndpointAuthSigningAlgValuesSupported) {
+		this.tokenEndpointAuthSigningAlgValuesSupported = tokenEndpointAuthSigningAlgValuesSupported;
+	}
+
+	@JsonProperty("userinfo_signing_alg_values_supported")
+	public List<String> getUserinfoSigningAlgValuesSupported() {
+		return userinfoSigningAlgValuesSupported;
+	}
+
+	@JsonProperty("userinfo_signing_alg_values_supported")
+	public void setUserinfoSigningAlgValuesSupported(List<String> userinfoSigningAlgValuesSupported) {
+		this.userinfoSigningAlgValuesSupported = userinfoSigningAlgValuesSupported;
+	}
+
+	@JsonProperty("jwks_uri")
+	public String getJwksUri() {
+		return jwksUri;
+	}
+
+	@JsonProperty("jwks_uri")
+	public void setJwksUri(String jwksUri) {
+		this.jwksUri = jwksUri;
+	}
+
+	@JsonProperty("subject_types_supported")
+	public List<String> getSubjectTypesSupported() {
+		return subjectTypesSupported;
+	}
+
+	@JsonProperty("subject_types_supported")
+	public void setSubjectTypesSupported(List<String> subjectTypesSupported) {
+		this.subjectTypesSupported = subjectTypesSupported;
+	}
+
+	@JsonProperty("id_token_signing_alg_values_supported")
+	public List<String> getIdTokenSigningAlgValuesSupported() {
+		return idTokenSigningAlgValuesSupported;
+	}
+
+	@JsonProperty("id_token_signing_alg_values_supported")
+	public void setIdTokenSigningAlgValuesSupported(List<String> idTokenSigningAlgValuesSupported) {
+		this.idTokenSigningAlgValuesSupported = idTokenSigningAlgValuesSupported;
+	}
+
+	@JsonProperty("token_endpoint_auth_methods_supported")
+	public List<String> getTokenEndpointAuthMethodsSupported() {
+		return tokenEndpointAuthMethodsSupported;
+	}
+
+	@JsonProperty("token_endpoint_auth_methods_supported")
+	public void setTokenEndpointAuthMethodsSupported(List<String> tokenEndpointAuthMethodsSupported) {
+		this.tokenEndpointAuthMethodsSupported = tokenEndpointAuthMethodsSupported;
+	}
+
+	@JsonProperty("token_endpoint")
+	public String getTokenEndpoint() {
+		return tokenEndpoint;
+	}
+
+	@JsonProperty("token_endpoint")
+	public void setTokenEndpoint(String tokenEndpoint) {
+		this.tokenEndpoint = tokenEndpoint;
+	}
+
+}

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/model/ValidationResponse.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/model/ValidationResponse.java
@@ -1,0 +1,48 @@
+package ca.bc.gov.open.ecrc.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * @author shaunmillargov
+ *
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "valid", "message" })
+public class ValidationResponse {
+
+	@JsonProperty("valid")
+	private boolean valid;
+
+	@JsonProperty("message")
+	private String message;
+	
+	public ValidationResponse() {}
+	
+	public ValidationResponse(boolean valid, String message) {
+		this.valid = valid; 
+		this.message = message; 
+	}
+
+	@JsonProperty("valid")
+	public boolean isValid() {
+		return valid;
+	}
+
+	@JsonProperty("valid")
+	public void setValid(boolean valid) {
+		this.valid = valid;
+	}
+
+	@JsonProperty("message")
+	public String getMessage() {
+		return message;
+	}
+
+	@JsonProperty("message")
+	public void setMessage(String message) {
+		this.message = message;
+	}
+
+}

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/service/ECRCJWTValidationService.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/service/ECRCJWTValidationService.java
@@ -1,0 +1,16 @@
+package ca.bc.gov.open.ecrc.service;
+
+import ca.bc.gov.open.ecrc.model.ValidationResponse;
+
+/**
+ * 
+ * BCSC JWT Token Validation Services.  
+ * 
+ * @author shaunmillargov
+ *
+ */
+public interface ECRCJWTValidationService {
+   public abstract ValidationResponse validateBCSCAccessToken(String token);
+   public abstract ValidationResponse validateBCSCIDToken(String token);
+   public abstract ValidationResponse PERValidate(String token);
+}

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/service/ECRCJWTValidationServiceImpl.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/service/ECRCJWTValidationServiceImpl.java
@@ -1,0 +1,188 @@
+package ca.bc.gov.open.ecrc.service;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Service;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.JWSKeySelector;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+
+import ca.bc.gov.open.ecrc.configuration.EcrcProperties;
+import ca.bc.gov.open.ecrc.model.ValidationResponse;
+import ca.bc.gov.open.ecrc.util.AES256;
+import net.minidev.json.JSONObject;
+import net.minidev.json.parser.JSONParser;
+
+/**
+ * 
+ * BCSC JWT Token Validation Services.  
+ * 
+ * These services are intended for validation of JWT token(s) received from BCSC.
+ * 
+ * @author shaunmillargov
+ * 
+ */
+@Service
+@Configuration
+@EnableConfigurationProperties(EcrcProperties.class)
+public class ECRCJWTValidationServiceImpl implements ECRCJWTValidationService {
+	
+	private final String[] BCSC_ACCESS_TOKEN_CLAIMS =  {"aud", "iss", "exp", "iat", "jti"}; 
+	private final String[] BCSC_ID_TOKEN_CLAIMS =  {"sub", "aud", "acr", "kid", "iss", "exp", "iat", "jti"}; 
+	
+	@Autowired
+	private EcrcProperties ecrcProps;
+
+	@Autowired
+	private OIDCConfigurationService oidcConfigService;
+	
+	/**
+	 * Validate BCSC Access Token 
+	 */
+	@Override
+	public ValidationResponse validateBCSCAccessToken(String token) { 
+		return validateBCSCToken(token, BCSC_ACCESS_TOKEN_CLAIMS);
+	}
+	
+	/**
+	 * Validate BCSC ID Token 
+	 */
+	@Override
+	public ValidationResponse validateBCSCIDToken(String token) {
+		return validateBCSCToken(token, BCSC_ID_TOKEN_CLAIMS);
+	}
+	
+   /**
+	* validateBCSCToken Performs the following checks: 
+	* 
+	*   - Algorithm check -- The JWS algorithm specified in the JWT header is
+	*     checked whether it matches the agreed / expected one. Signature check
+	*   - The digital signature is verified by trying an appropriate public
+	*     key from the server JWK set of the remote server. 
+	*   - JWT claims check -- The JWT claims set is validated, for example to ensure the token is
+	*     not expired and matches the expected issuer, audience and other
+	*     claims. 
+	*     
+	*     Applicable to both access_token and id_token types. 
+	*   
+	**/
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private ValidationResponse validateBCSCToken(String token, String[] claims) {
+
+		ValidationResponse val = new ValidationResponse(true, "Successful JWT validation");
+
+		// Create a JWT processor for the access tokens
+		ConfigurableJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+
+		// Fetch the public RSA keys from the IdP server to validate the signatures
+		// Keys are sourced from the IdP server's JWK set, published at a well-known URL.
+		// The RemoteJWKSet object caches the retrieved keys to speed up subsequent look-ups and can
+		// also handle key-rollovers.
+		JWKSource<SecurityContext> keySource = null;
+		try {
+			keySource = new RemoteJWKSet<>(new URL(oidcConfigService.getConfig().getJwksUri()));
+		} catch (MalformedURLException e1) {
+			System.out.println("Unable to instantiate Remote JWK set from remote server. " + e1.getMessage());
+			val.setMessage(e1.getMessage());
+			e1.printStackTrace();
+		}
+
+		// The expected JWS algorithm of the id_Token received from BCSC
+		JWSAlgorithm expectedJWSAlg = JWSAlgorithm.RS256;
+
+		// Configure the JWT processor with a key selector to feed matching public
+		// RSA keys sourced from the JWK set URL
+		JWSKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(expectedJWSAlg, keySource);
+
+		jwtProcessor.setJWSKeySelector(keySelector);
+
+		// Set the required JWT claims for access tokens issued by the IdP (BCSC) server.
+		// This set MUST match those found for the ID_TOKEN rec'd back from BCSC.
+		jwtProcessor.setJWTClaimsSetVerifier(new DefaultJWTClaimsVerifier(
+				// new JWTClaimsSet.Builder().issuer("https://idtest.gov.bc.ca/oauth2/").build(),
+				new JWTClaimsSet.Builder().issuer(ecrcProps.getOauthIdp() + "/oauth2/").build(),
+				new HashSet<>(Arrays.asList(claims))));
+
+		// Process the token
+		SecurityContext ctx = null; // optional context parameter, not required here
+		try {
+			jwtProcessor.process(token, ctx);
+		} catch (ParseException | BadJOSEException | JOSEException e) {
+			val.setMessage(e.getMessage());
+			val.setValid(false);
+			e.printStackTrace();
+		}
+
+		return val;
+	}
+
+
+	/**
+	 * Validate the PER claim (Decrypt and validate the BCSC tokens within).
+	 * 
+	 * MIGHT NOT BE USED. 
+	 */
+	@Override
+	public ValidationResponse PERValidate(String tokens) {
+		
+		// Decrypt the original claim (labeled "PER") containing the tokens BCSC
+		String _tokens = AES256.decrypt(tokens); 
+		JSONParser p = new JSONParser(JSONParser.MODE_RFC4627);
+		JSONObject obj;
+		TokenResponse response = null; 
+		try {
+			obj = (JSONObject) p.parse(_tokens);
+			response = TokenResponse.parse(obj);
+		} catch (net.minidev.json.parser.ParseException e) {
+			e.printStackTrace();
+		} catch (com.nimbusds.oauth2.sdk.ParseException e) {
+			e.printStackTrace();
+		}
+		
+		// Fetch both tokens within the decrypted string. 
+		AccessToken accessToken = response.toSuccessResponse().getTokens().getAccessToken();
+		String idToken = (String) response.toSuccessResponse().getCustomParameters().get("id_token");
+		
+		//System.out.println(accessToken.getValue()); 
+		//System.out.println(idToken);
+		
+		ValidationResponse val1 = validateBCSCAccessToken(accessToken.getValue());
+		ValidationResponse val2 = validateBCSCIDToken(idToken);
+		Boolean bothValid = val1.isValid() && val2.isValid();
+		ValidationResponse resp = new ValidationResponse();
+		
+		// merge the response of two tests into one. 
+		if ( !bothValid ) {
+			resp.setValid(false);
+			if ( !val1.isValid() ) 
+				resp.setMessage( val1.getMessage() );
+			else 
+				resp.setMessage( val2.getMessage());
+		} else {
+			resp.setValid(true);
+			resp.setMessage("Successful JWT validation");
+		}
+
+		return resp; 
+	}
+
+}

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/service/OIDCConfigurationService.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/service/OIDCConfigurationService.java
@@ -60,3 +60,4 @@ public class OIDCConfigurationService {
 		}
 	}
 }
+

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/service/OIDCConfigurationService.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/service/OIDCConfigurationService.java
@@ -1,0 +1,62 @@
+package ca.bc.gov.open.ecrc.service;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import ca.bc.gov.open.ecrc.configuration.EcrcProperties;
+import ca.bc.gov.open.ecrc.model.OIDCConfiguration;
+
+
+/**
+ * 
+ * Service Returns a JAVA object which represents OpenID Connect configuration values from the provider's 
+ * Well-Known Configuration Endpoint. 
+ * 
+ * @author shaunmillargov
+ *
+ */
+@Service
+@Configuration
+@EnableConfigurationProperties(EcrcProperties.class)
+public class OIDCConfigurationService {
+	
+	private OIDCConfiguration config = null; 
+	
+	@Autowired
+	private EcrcProperties ecrcProps;
+	
+	/**
+	 * 
+	 * Loads the OIDC Well-known config endpoint if not already loaded. 
+	 * 
+	 * @return
+	 */
+    public OIDCConfiguration getConfig() {
+        if ( null == config ) 
+        	loadConfig();
+        return config;
+    }
+
+    /**
+     * 
+     * Loads config object. 
+     * 
+     */
+	private void loadConfig() {
+		RestTemplate restTemplate = new RestTemplate();
+		URI uri = null;
+		try {
+			uri = new URI(ecrcProps.getOauthWellKnown());
+			config = restTemplate.getForObject(uri, OIDCConfiguration.class);
+		} catch (URISyntaxException e2) {
+			System.out.println("Unable to load remote server Well-Known configuration endpoint. " + e2.getMessage()); 
+			e2.printStackTrace();
+		}
+	}
+}


### PR DESCRIPTION
Includes method for validating "PER" blob in FE tokens.

# Description

Added new service for validating tokens received from BCSC after call to /token AND validating the current FE "PER" encrypted object. 

NOTE: This service is not yet in operation nor have tests been written for its methods.  

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

All methods have been tested using a manual procedure of obtaining the FE JWT token. "PER" block was decrypted to reveal original access_token and id_token. Both tokens were validated using the new service methods before and after expiring.  

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: **SPDBCSC-256**
