### PR TITLE
spdbcsc-256_1: Hooked up BCSC token validation service to result of /…

### DIFF
--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/controller/OauthController.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/controller/OauthController.java
@@ -113,7 +113,13 @@ public class OauthController {
 		}
 		
 		// Fetch corresponding Userinfo from the IdP server.  
-		JSONObject userInfo = oauthServices.getUserInfo((BearerAccessToken)token.toSuccessResponse().getTokens().getAccessToken());
+		JSONObject userInfo = null; 
+		try {
+			userInfo = oauthServices.getUserInfo((BearerAccessToken)token.toSuccessResponse().getTokens().getAccessToken());
+		} catch (OauthServiceException e) {
+			logger.error("Error fetching userinfo. " + e.getMessage(), e);
+			return new ResponseEntity<String>(HttpStatus.FORBIDDEN);
+		}
 		
 		// Encrypt the token received from the IdP. This token contains the accessToken, the refreshToken, and the ID Token. This block 
 		// must be decrypted and used for subsequent calls back to the IdP from this layer (e.g. /refreshToken). 

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/service/ECRCJWTValidationServiceImpl.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/service/ECRCJWTValidationServiceImpl.java
@@ -6,6 +6,8 @@ import java.text.ParseException;
 import java.util.Arrays;
 import java.util.HashSet;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -55,11 +57,14 @@ public class ECRCJWTValidationServiceImpl implements ECRCJWTValidationService {
 	@Autowired
 	private OIDCConfigurationService oidcConfigService;
 	
+	private Logger logger = LoggerFactory.getLogger(ECRCJWTValidationServiceImpl.class);
+	
 	/**
 	 * Validate BCSC Access Token 
 	 */
 	@Override
 	public ValidationResponse validateBCSCAccessToken(String token) { 
+		logger.debug("validateBCSCAccessToken called. Token = " + token);
 		return validateBCSCToken(token, BCSC_ACCESS_TOKEN_CLAIMS);
 	}
 	
@@ -68,6 +73,7 @@ public class ECRCJWTValidationServiceImpl implements ECRCJWTValidationService {
 	 */
 	@Override
 	public ValidationResponse validateBCSCIDToken(String token) {
+		logger.debug("validateBCSCIDToken called. Token = " + token);
 		return validateBCSCToken(token, BCSC_ID_TOKEN_CLAIMS);
 	}
 	
@@ -101,7 +107,7 @@ public class ECRCJWTValidationServiceImpl implements ECRCJWTValidationService {
 		try {
 			keySource = new RemoteJWKSet<>(new URL(oidcConfigService.getConfig().getJwksUri()));
 		} catch (MalformedURLException e1) {
-			System.out.println("Unable to instantiate Remote JWK set from remote server. " + e1.getMessage());
+			logger.error("Unable to instantiate Remote JWK set from remote server. " + e1.getMessage());
 			val.setMessage(e1.getMessage());
 			e1.printStackTrace();
 		}
@@ -126,7 +132,9 @@ public class ECRCJWTValidationServiceImpl implements ECRCJWTValidationService {
 		SecurityContext ctx = null; // optional context parameter, not required here
 		try {
 			jwtProcessor.process(token, ctx);
+			logger.debug("Token Ok");
 		} catch (ParseException | BadJOSEException | JOSEException e) {
+			logger.error("Token FAILED validation. " + e.getMessage(), e);
 			val.setMessage(e.getMessage());
 			val.setValid(false);
 			e.printStackTrace();

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/service/OIDCConfigurationService.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/service/OIDCConfigurationService.java
@@ -3,6 +3,8 @@ package ca.bc.gov.open.ecrc.service;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -25,6 +27,8 @@ import ca.bc.gov.open.ecrc.model.OIDCConfiguration;
 @Configuration
 @EnableConfigurationProperties(EcrcProperties.class)
 public class OIDCConfigurationService {
+	
+	private Logger logger = LoggerFactory.getLogger(OIDCConfigurationService.class);
 	
 	private OIDCConfiguration config = null; 
 	
@@ -55,7 +59,7 @@ public class OIDCConfigurationService {
 			uri = new URI(ecrcProps.getOauthWellKnown());
 			config = restTemplate.getForObject(uri, OIDCConfiguration.class);
 		} catch (URISyntaxException e2) {
-			System.out.println("Unable to load remote server Well-Known configuration endpoint. " + e2.getMessage()); 
+			logger.error("Unable to load remote server Well-Known configuration endpoint. Check Oauth2 well-known endpoint configuration. " + e2.getMessage(), e2); 
 			e2.printStackTrace();
 		}
 	}

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/service/OauthServicesImpl.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/service/OauthServicesImpl.java
@@ -116,7 +116,7 @@ public class OauthServicesImpl implements OauthServices {
 
 			if (!response.indicatesSuccess()) {
 			    TokenErrorResponse errorResponse = response.toErrorResponse();
-				throw new OauthServiceException("Token Error Response from IdP server: " + errorResponse.toString() );
+				throw new OauthServiceException("Token Error Response from IdP server: " + errorResponse.toJSONObject().toJSONString());
 			}
 
 			// Respond with the complete token returned from the IdP.

--- a/src/ecrc-api/src/test/java/ca/bc/gov/open/ecrc/configuration/EcrcPropertiesTest.java
+++ b/src/ecrc-api/src/test/java/ca/bc/gov/open/ecrc/configuration/EcrcPropertiesTest.java
@@ -44,6 +44,8 @@ class EcrcPropertiesTest {
 		Assert.assertEquals("5678", ecrcProperties.getOauthSecret());
 		Assert.assertEquals("api", ecrcProperties.getOauthScope());
 		Assert.assertEquals("returnuri", ecrcProperties.getOauthReturnUri());
+		Assert.assertEquals("wellknown", ecrcProperties.getOauthWellKnown());
+		
 		Assert.assertEquals(3000, ecrcProperties.getOauthJwtExpiry());
 	}
 

--- a/src/ecrc-api/src/test/resources/application-test.properties
+++ b/src/ecrc-api/src/test/resources/application-test.properties
@@ -49,6 +49,7 @@ ecrc.oauth-return-uri=returnuri
 ecrc.oauth-userinfo-path=/test
 ecrc.oauth-token-path=/test
 ecrc.oauth-authorize-path=/test
+ecrc.oauth-well-known=wellknown
 
 #JWT token expiry in milliseconds
 ecrc.oauth-jwt-expiry=3000


### PR DESCRIPTION

# Description

Added logging and connected Oauth2 token validation service to response of /token request from BCSC Modified controller to properly return 403 if token request or token validation fails. 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually tested all cases. Unit tests not yet implemented. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: **SPDBCSC-256**
