### PR TITLE
add message to notify user to scroll in Terms of use page

### DIFF
--- a/src/ecrc-frontend/src/__snapshots__/storyshots.test.js.snap
+++ b/src/ecrc-frontend/src/__snapshots__/storyshots.test.js.snap
@@ -10309,6 +10309,18 @@ exports[`Storyshots Term Of Use page Default 1`] = `
           </ol>
         </section>
         <section>
+          <p
+            style={
+              Object {
+                "color": "red",
+              }
+            }
+          >
+            Please scroll down to the bottom of the terms of use and agree to the terms below to continue.
+          </p>
+        </section>
+        <br />
+        <section>
           <input
             className="terms-cb"
             onClick={[Function]}
@@ -10800,6 +10812,18 @@ exports[`Storyshots Term Of Use page Mobile 1`] = `
           </ol>
         </section>
         <section>
+          <p
+            style={
+              Object {
+                "color": "red",
+              }
+            }
+          >
+            Please scroll down to the bottom of the terms of use and agree to the terms below to continue.
+          </p>
+        </section>
+        <br />
+        <section>
           <input
             className="terms-cb"
             onClick={[Function]}
@@ -11220,6 +11244,18 @@ exports[`Storyshots Terms of Use Default 1`] = `
       </li>
     </ol>
   </section>
+  <section>
+    <p
+      style={
+        Object {
+          "color": "red",
+        }
+      }
+    >
+      Please scroll down to the bottom of the terms of use and agree to the terms below to continue.
+    </p>
+  </section>
+  <br />
   <section>
     <input
       className="terms-cb"

--- a/src/ecrc-frontend/src/components/base/termsOfUse/TermsOfUse.js
+++ b/src/ecrc-frontend/src/components/base/termsOfUse/TermsOfUse.js
@@ -408,6 +408,16 @@ export default function TermsOfUse({
         </ol>
       </section>
 
+      {!continueBtnEnabled && (
+        <section>
+          <p style={{ color: "red" }}>
+            Please scroll down to the bottom of the terms of use and agree to
+            the terms below to continue.
+          </p>
+        </section>
+      )}
+      <br />
+
       <section>
         <input type="checkbox" className="terms-cb" onClick={checkFirstBox} />
         &nbsp;I have read and accept the above terms and conditions.

--- a/src/ecrc-frontend/src/components/base/termsOfUse/__snapshots__/TermsOfUse.test.js.snap
+++ b/src/ecrc-frontend/src/components/base/termsOfUse/__snapshots__/TermsOfUse.test.js.snap
@@ -302,6 +302,18 @@ exports[`TermsOfUse Component Matches the snapshot 1`] = `
     </ol>
   </section>
   <section>
+    <p
+      style={
+        Object {
+          "color": "red",
+        }
+      }
+    >
+      Please scroll down to the bottom of the terms of use and agree to the terms below to continue.
+    </p>
+  </section>
+  <br />
+  <section>
     <input
       className="terms-cb"
       onClick={[Function]}

--- a/src/ecrc-frontend/src/components/page/tou/__snapshots__/TOU.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/tou/__snapshots__/TOU.test.js.snap
@@ -371,6 +371,18 @@ exports[`TermOfUse Page Component Matches the snapshot 1`] = `
           </ol>
         </section>
         <section>
+          <p
+            style={
+              Object {
+                "color": "red",
+              }
+            }
+          >
+            Please scroll down to the bottom of the terms of use and agree to the terms below to continue.
+          </p>
+        </section>
+        <br />
+        <section>
           <input
             className="terms-cb"
             onClick={[Function]}


### PR DESCRIPTION
# Description

Add message indicating to the user what needs to be done to proceed from TOU page.

<img width="1207" alt="Screen Shot 2020-03-11 at 9 06 25 PM" src="https://user-images.githubusercontent.com/55710226/76486337-54824580-63dc-11ea-9586-56420bd38bee.png">
<img width="1206" alt="Screen Shot 2020-03-11 at 9 06 34 PM" src="https://user-images.githubusercontent.com/55710226/76486339-55b37280-63dc-11ea-8415-dd0eff39e979.png">

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally and jest

## For bcgov contributors:

this PR fixes jira ticket: **https://justice.gov.bc.ca/jira/browse/SPDBCSC-378**
