### PR TITLE
Fix: Fixed implementation to allow browser routing

### DIFF
--- a/src/ecrc-frontend/package.json
+++ b/src/ecrc-frontend/package.json
@@ -1,7 +1,6 @@
 {
   "name": "ecrc-frontend",
   "version": "0.1.0",
-  "homepage": "/criminalrecordcheck",
   "private": true,
   "dependencies": {
     "@bcgov/bootstrap-theme": "https://github.com/bcgov/bootstrap-theme/releases/download/v1.1.1/bcgov-bootstrap-theme-1.1.1.tgz",

--- a/src/ecrc-frontend/src/App.js
+++ b/src/ecrc-frontend/src/App.js
@@ -88,11 +88,7 @@ export default function App() {
             page={{
               header,
               applicant,
-              org,
-              setApplicationInfo,
-              saveOrg,
-              saveApplicant,
-              saveApplicationInfo
+              org
             }}
           />
         </Route>

--- a/src/ecrc-frontend/src/App.js
+++ b/src/ecrc-frontend/src/App.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Switch, Route, BrowserRouter, Redirect } from "react-router-dom";
+import { Switch, Route, Redirect } from "react-router-dom";
 import OrgValidation from "./components/page/orgValidation/OrgValidation";
 import OrgVerification from "./components/page/orgVerification/OrgVerification";
 import ApplicationForm from "./components/page/applicationForm/ApplicationForm";
@@ -45,72 +45,70 @@ export default function App() {
 
   return (
     <div>
-      <BrowserRouter>
-        <Switch>
-          <Redirect exact from="/" to="/criminalrecordcheck" />
-          <Route exact path="/(ecrc|criminalrecordcheck)">
-            <OrgValidation
-              page={{ header, setOrg, setTransitionReason, setError }}
-            />
-          </Route>
-          <Route path="/(ecrc/orgverification|criminalrecordcheck/orgverification)">
-            <OrgVerification page={{ header, org }} />
-          </Route>
-          <Route path="/(ecrc/applicationform|criminalrecordcheck/applicationform)">
-            <ApplicationForm page={{ header, org, applicant, setApplicant }} />
-          </Route>
-          <Route path="/(ecrc/transition|criminalrecordcheck/transition)">
-            <Transition page={{ header, transitionReason }} />
-          </Route>
-          <Route path="/(ecrc/termsofuse|criminalrecordcheck/termsofuse)">
-            <TOU page={{ header }} />
-          </Route>
-          <Route path="/(ecrc/consent|criminalrecordcheck/consent)">
-            <UserConfirmation page={{ header, setApplicant }} />
-          </Route>
-          <Route path="/(ecrc/bcscredirect|criminalrecordcheck/bcscredirect)">
-            <BcscRedirect page={{ header, saveOrg }} />
-          </Route>
-          <Route path="/(ecrc/success|criminalrecordcheck/success)">
-            <Success
-              page={{
-                header,
-                applicant,
-                org,
-                applicationInfo,
-                saveApplicationInfo
-              }}
-            />
-          </Route>
-          <Route path="/(ecrc/informationreview|criminalrecordcheck/informationreview)">
-            <InformationReview
-              page={{
-                header,
-                applicant,
-                org,
-                setApplicationInfo,
-                saveOrg,
-                saveApplicant,
-                saveApplicationInfo
-              }}
-            />
-          </Route>
-          <Route path="/(ecrc/userconfirmation|criminalrecordcheck/userconfirmation)">
-            <Consent page={{ header }} />
-          </Route>
-          <Route path="/(ecrc/error|criminalrecordcheck/error)">
-            <Error page={{ header, error }} />
-          </Route>
-          <Route
-            path="/hosthome"
-            component={() => {
-              window.location.href =
-                "https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check";
-              return null;
+      <Switch>
+        <Redirect exact from="/" to="/criminalrecordcheck" />
+        <Route exact path="/(ecrc|criminalrecordcheck)">
+          <OrgValidation
+            page={{ header, setOrg, setTransitionReason, setError }}
+          />
+        </Route>
+        <Route path="/(ecrc/orgverification|criminalrecordcheck/orgverification)">
+          <OrgVerification page={{ header, org }} />
+        </Route>
+        <Route path="/(ecrc/applicationform|criminalrecordcheck/applicationform)">
+          <ApplicationForm page={{ header, org, applicant, setApplicant }} />
+        </Route>
+        <Route path="/(ecrc/transition|criminalrecordcheck/transition)">
+          <Transition page={{ header, transitionReason }} />
+        </Route>
+        <Route path="/(ecrc/termsofuse|criminalrecordcheck/termsofuse)">
+          <TOU page={{ header }} />
+        </Route>
+        <Route path="/(ecrc/consent|criminalrecordcheck/consent)">
+          <UserConfirmation page={{ header, setApplicant }} />
+        </Route>
+        <Route path="/(ecrc/bcscredirect|criminalrecordcheck/bcscredirect)">
+          <BcscRedirect page={{ header, saveOrg }} />
+        </Route>
+        <Route path="/(ecrc/success|criminalrecordcheck/success)">
+          <Success
+            page={{
+              header,
+              applicant,
+              org,
+              applicationInfo,
+              saveApplicationInfo
             }}
           />
-        </Switch>
-      </BrowserRouter>
+        </Route>
+        <Route path="/(ecrc/informationreview|criminalrecordcheck/informationreview)">
+          <InformationReview
+            page={{
+              header,
+              applicant,
+              org,
+              setApplicationInfo,
+              saveOrg,
+              saveApplicant,
+              saveApplicationInfo
+            }}
+          />
+        </Route>
+        <Route path="/(ecrc/userconfirmation|criminalrecordcheck/userconfirmation)">
+          <Consent page={{ header }} />
+        </Route>
+        <Route path="/(ecrc/error|criminalrecordcheck/error)">
+          <Error page={{ header, error }} />
+        </Route>
+        <Route
+          path="/hosthome"
+          component={() => {
+            window.location.href =
+              "https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check";
+            return null;
+          }}
+        />
+      </Switch>
     </div>
   );
 }

--- a/src/ecrc-frontend/src/components/page/applicationForm/ApplicationForm.js
+++ b/src/ecrc-frontend/src/components/page/applicationForm/ApplicationForm.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
-import { Redirect } from "react-router-dom";
+import { Redirect, useHistory } from "react-router-dom";
 import PropTypes from "prop-types";
 
 import "./ApplicationForm.css";
@@ -51,8 +51,8 @@ export default function ApplicationForm({
     org: { defaultScheduleTypeCd }
   }
 }) {
+  const history = useHistory();
   const [toHome, setToHome] = useState(false);
-  const [toInfoReview, setToInfoReview] = useState(false);
   const [previousNames, setPreviousNames] = useState({
     previousTwo: alias2FirstNm || alias2SecondNm || alias2SurnameNm,
     previousThree: alias3FirstNm || alias3SecondNm || alias3SurnameNm
@@ -555,7 +555,15 @@ export default function ApplicationForm({
         organizationFacility: organizationLocation
       });
 
-      setToInfoReview(true);
+      const currentPayload = accessJWTToken(sessionStorage.getItem("jwt"));
+      const actionsPerformed = [...currentPayload.actionsPerformed, "appForm"];
+      const newPayload = {
+        ...currentPayload,
+        actionsPerformed
+      };
+      generateJWTToken(newPayload);
+
+      history.push("/criminalrecordcheck/informationreview");
     }
   };
 
@@ -579,17 +587,6 @@ export default function ApplicationForm({
 
   if (toHome) {
     return <Redirect to="/" />;
-  }
-
-  if (toInfoReview) {
-    const currentPayload = accessJWTToken(sessionStorage.getItem("jwt"));
-    const actionsPerformed = [...currentPayload.actionsPerformed, "appForm"];
-    const newPayload = {
-      ...currentPayload,
-      actionsPerformed
-    };
-    generateJWTToken(newPayload);
-    return <Redirect to="/criminalrecordcheck/informationreview" />;
   }
 
   return (

--- a/src/ecrc-frontend/src/components/page/applicationForm/ApplicationForm.test.js
+++ b/src/ecrc-frontend/src/components/page/applicationForm/ApplicationForm.test.js
@@ -86,7 +86,11 @@ describe("ApplicationForm Component", () => {
   });
 
   test("Displays Organization Facility when Schedule D Org", async () => {
-    const { container } = render(<ApplicationForm page={page} />);
+    const { container } = render(
+      <MemoryRouter>
+        <ApplicationForm page={page} />
+      </MemoryRouter>
+    );
     await wait(() => {});
 
     expect(getByText(container, "Organization Facility")).toBeInTheDocument();
@@ -94,9 +98,11 @@ describe("ApplicationForm Component", () => {
 
   test("Does not display Organization Facility when not Schedule D Org", async () => {
     const { container } = render(
-      <ApplicationForm
-        page={{ ...page, org: { defaultScheduleTypeCd: "WBSC" } }}
-      />
+      <MemoryRouter>
+        <ApplicationForm
+          page={{ ...page, org: { defaultScheduleTypeCd: "WBSC" } }}
+        />
+      </MemoryRouter>
     );
     await wait(() => {});
 
@@ -104,7 +110,11 @@ describe("ApplicationForm Component", () => {
   });
 
   test("Displays Additional Aliases", async () => {
-    const { container } = render(<ApplicationForm page={page} />);
+    const { container } = render(
+      <MemoryRouter>
+        <ApplicationForm page={page} />
+      </MemoryRouter>
+    );
     await wait(() => {});
 
     expect(queryAllByText(container, "First Name")).toHaveLength(3);
@@ -133,9 +143,11 @@ describe("ApplicationForm Component", () => {
     };
 
     const { container } = render(
-      <ApplicationForm
-        page={{ ...page, applicant: { ...returningApplicant } }}
-      />
+      <MemoryRouter>
+        <ApplicationForm
+          page={{ ...page, applicant: { ...returningApplicant } }}
+        />
+      </MemoryRouter>
     );
     await wait(() => {});
 

--- a/src/ecrc-frontend/src/components/page/consent/Consent.js
+++ b/src/ecrc-frontend/src/components/page/consent/Consent.js
@@ -68,7 +68,8 @@ export default function Consent({ page: { header, setError } }) {
   const toApplicationForm = () => {
     if (!isAuthorized()) {
       setError("session expired");
-      return setToError(true);
+      setToError(true);
+      return;
     }
 
     const currentPayload = accessJWTToken(sessionStorage.getItem("jwt"));

--- a/src/ecrc-frontend/src/components/page/consent/Consent.js
+++ b/src/ecrc-frontend/src/components/page/consent/Consent.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-one-expression-per-line */
 import React, { useState, useEffect } from "react";
-import { Redirect } from "react-router-dom";
+import { Redirect, useHistory } from "react-router-dom";
 import PropTypes from "prop-types";
 
 import Header from "../../base/header/Header";
@@ -17,9 +17,9 @@ import {
 } from "../../../modules/AuthenticationHelper";
 
 export default function Consent({ page: { header } }) {
+  const history = useHistory();
   const [toAppHome, setToAppHome] = useState(false);
   const [toHome, setToHome] = useState(false);
-  const [toApplicationForm, setToApplicationForm] = useState(false);
   const [firstBoxChecked, setFirstBoxChecked] = useState(false);
   const [secondBoxChecked, setSecondBoxChecked] = useState(false);
   const [thirdBoxChecked, setThirdBoxChecked] = useState(false);
@@ -64,7 +64,7 @@ export default function Consent({ page: { header } }) {
     return <Redirect to="/" />;
   }
 
-  if (toApplicationForm) {
+  const toApplicationForm = () => {
     const currentPayload = accessJWTToken(sessionStorage.getItem("jwt"));
     const actionsPerformed = [...currentPayload.actionsPerformed, "consent"];
     const newPayload = {
@@ -72,8 +72,9 @@ export default function Consent({ page: { header } }) {
       actionsPerformed
     };
     generateJWTToken(newPayload);
-    return <Redirect to="/criminalrecordcheck/applicationform" />;
-  }
+
+    history.push("/criminalrecordcheck/applicationform");
+  };
 
   const asterisk = (
     <span id="asterisk" className="mandatory">
@@ -109,7 +110,7 @@ export default function Consent({ page: { header } }) {
             <Button
               button={continueButton}
               onClick={() => {
-                setToApplicationForm(true);
+                toApplicationForm();
               }}
             />
           </div>

--- a/src/ecrc-frontend/src/components/page/consent/Consent.js
+++ b/src/ecrc-frontend/src/components/page/consent/Consent.js
@@ -100,6 +100,23 @@ export default function Consent({
     loader: loading
   };
 
+  const toSuccess = () => {
+    if (!isAuthorized()) {
+      setError("session expired");
+      setToError(true);
+      return;
+    }
+
+    const currentPayload = accessJWTToken(sessionStorage.getItem("jwt"));
+    const newPayload = {
+      ...currentPayload,
+      actionsPerformed: [...currentPayload.actionsPerformed, "consent"]
+    };
+    generateJWTToken(newPayload);
+
+    history.push("/criminalrecordcheck/success");
+  };
+
   const confirm = () => {
     setLoading(true);
 
@@ -268,23 +285,6 @@ export default function Consent({
   if (toAppHome) {
     return <Redirect to="/" />;
   }
-
-  const toSuccess = () => {
-    if (!isAuthorized()) {
-      setError("session expired");
-      setToError(true);
-      return;
-    }
-
-    const currentPayload = accessJWTToken(sessionStorage.getItem("jwt"));
-    const newPayload = {
-      ...currentPayload,
-      actionsPerformed: [...currentPayload.actionsPerformed, "consent"]
-    };
-    generateJWTToken(newPayload);
-
-    history.push("/criminalrecordcheck/success");
-  };
 
   const asterisk = (
     <span id="asterisk" className="mandatory">

--- a/src/ecrc-frontend/src/components/page/consent/Consent.test.js
+++ b/src/ecrc-frontend/src/components/page/consent/Consent.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { create } from "react-test-renderer";
-import { Router } from "react-router-dom";
+import { Router, MemoryRouter } from "react-router-dom";
 import {
   render,
   fireEvent,
@@ -33,7 +33,11 @@ describe("Consent Page Component", () => {
   });
 
   test("Matches the snapshot", () => {
-    const consent = create(<Consent page={page} />);
+    const consent = create(
+      <MemoryRouter>
+        <Consent page={page} />
+      </MemoryRouter>
+    );
     expect(consent.toJSON()).toMatchSnapshot();
   });
 

--- a/src/ecrc-frontend/src/components/page/informationreview/InformationReview.js
+++ b/src/ecrc-frontend/src/components/page/informationreview/InformationReview.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Redirect } from "react-router-dom";
+import { Redirect, useHistory } from "react-router-dom";
 import PropTypes from "prop-types";
 
 import Header from "../../base/header/Header";
@@ -51,9 +51,8 @@ export default function InformationReview({
     setError
   }
 }) {
-  const [toBack, setToBack] = useState(false);
+  const history = useHistory();
   const [toHome, setToHome] = useState(false);
-  const [toConsent, setToConsent] = useState(false);
   const [toError, setToError] = useState(false);
   const [boxChecked, setBoxChecked] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -269,7 +268,7 @@ export default function InformationReview({
   };
 
   const edit = () => {
-    setToBack(true);
+    history.push("/criminalrecordcheck/applicationform");
   };
 
   const confirm = () => {
@@ -281,22 +280,15 @@ export default function InformationReview({
       return;
     }
 
-    setToConsent(true);
-  };
-
-  if (toBack) {
-    return <Redirect to="/criminalrecordcheck/applicationform" />;
-  }
-
-  if (toConsent) {
     const currentPayload = accessJWTToken(sessionStorage.getItem("jwt"));
     const newPayload = {
       ...currentPayload,
       actionsPerformed: [...currentPayload.actionsPerformed, "infoReview"]
     };
     generateJWTToken(newPayload);
-    return <Redirect to="/criminalrecordcheck/userconfirmation" />;
-  }
+
+    history.push("/criminalrecordcheck/userconfirmation");
+  };
 
   if (toHome) {
     return <Redirect to="/" />;

--- a/src/ecrc-frontend/src/components/page/orgValidation/OrgValidation.js
+++ b/src/ecrc-frontend/src/components/page/orgValidation/OrgValidation.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
-import { Redirect } from "react-router-dom";
+import { Redirect, useHistory } from "react-router-dom";
 import axios from "axios";
 import Header from "../../base/header/Header";
 import Footer from "../../base/footer/Footer";
@@ -16,10 +16,9 @@ import {
 export default function OrgValidation({
   page: { header, setOrg, setTransitionReason, setError }
 }) {
+  const history = useHistory();
   const [orgTicketNumber, setOrgTicketNumber] = useState("");
   const [orgError, setOrgError] = useState("");
-  const [toTransition, setToTransition] = useState(false);
-  const [toOrgVerification, setToOrgVerification] = useState(false);
   const [toError, setToError] = useState(false);
   const payload = { authorities: ["ROLE"] };
   const token = generateJWTToken(payload);
@@ -46,14 +45,14 @@ export default function OrgValidation({
       )
       .then(res => {
         setOrg({ ...res.data.accessCodeResponse, orgTicketNumber });
-        setToOrgVerification(true);
+        history.push("/criminalrecordcheck/orgverification");
       })
       .catch(error => {
         if (error.response.status === 404) {
           setOrgError("Please enter a valid org code");
         } else if (error.response.status === 401) {
           setTransitionReason("notwhitelisted");
-          setToTransition(true);
+          history.push("/criminalrecordcheck/transition");
         } else {
           setToError(true);
           setError(error.response.status.toString());
@@ -75,14 +74,6 @@ export default function OrgValidation({
     buttonSize: "btn btn-sm",
     type: "submit"
   };
-
-  if (toOrgVerification) {
-    return <Redirect to="/criminalrecordcheck/orgverification" />;
-  }
-
-  if (toTransition) {
-    return <Redirect to="/criminalrecordcheck/transition" />;
-  }
 
   if (toError) {
     return <Redirect to="/criminalrecordcheck/error" />;

--- a/src/ecrc-frontend/src/components/page/orgVerification/OrgVerification.js
+++ b/src/ecrc-frontend/src/components/page/orgVerification/OrgVerification.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-one-expression-per-line */
 import React, { useState, useEffect } from "react";
-import { Redirect } from "react-router-dom";
+import { Redirect, useHistory } from "react-router-dom";
 import PropTypes from "prop-types";
 
 import "../page.css";
@@ -17,8 +17,8 @@ import {
 } from "../../../modules/AuthenticationHelper";
 
 export default function OrgVerification({ page: { header, org } }) {
+  const history = useHistory();
   const [toHome, setToHome] = useState(false);
-  const [toTOU, setToTOU] = useState(false);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -37,7 +37,7 @@ export default function OrgVerification({ page: { header, org } }) {
       actionsPerformed: ["orgVerification"]
     };
     generateJWTToken(newPayload);
-    setToTOU(true);
+    history.push("/criminalrecordcheck/termsofuse");
   };
 
   const back = () => {
@@ -121,10 +121,6 @@ export default function OrgVerification({ page: { header, org } }) {
 
   if (toHome) {
     return <Redirect to="/" />;
-  }
-
-  if (toTOU) {
-    return <Redirect to="/criminalrecordcheck/termsofuse" />;
   }
 
   return (

--- a/src/ecrc-frontend/src/components/page/tou/TOU.js
+++ b/src/ecrc-frontend/src/components/page/tou/TOU.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
-import { Redirect } from "react-router-dom";
+import { Redirect, useHistory } from "react-router-dom";
 
 import Header from "../../base/header/Header";
 import Footer from "../../base/footer/Footer";
@@ -14,7 +14,7 @@ import {
 } from "../../../modules/AuthenticationHelper";
 
 export default function TOU({ page: { header } }) {
-  const [toBCSCRedirect, setToBCSCRedirect] = useState(false);
+  const history = useHistory();
   const [toHome, setToHome] = useState(false);
   const [secondBoxChecked, setSecondBoxChecked] = useState(false);
   const [firstBoxChecked, setFirstBoxChecked] = useState(false);
@@ -38,10 +38,6 @@ export default function TOU({ page: { header } }) {
   }, [firstBoxChecked, secondBoxChecked, reachedEnd]);
 
   const onContinueClick = () => {
-    setToBCSCRedirect(true);
-  };
-
-  if (toBCSCRedirect) {
     const currentPayload = accessJWTToken(sessionStorage.getItem("jwt"));
     const actionsPerformed = [...currentPayload.actionsPerformed, "tou"];
     const newPayload = {
@@ -49,8 +45,10 @@ export default function TOU({ page: { header } }) {
       actionsPerformed
     };
     generateJWTToken(newPayload);
-    return <Redirect to="/criminalrecordcheck/bcscredirect" />;
-  }
+
+    history.push("/criminalrecordcheck/bcscredirect");
+  };
+
   const termOfUseOnScroll = event => {
     const { scrollHeight, scrollTop, clientHeight } = event.target;
     if (!reachedEnd && scrollHeight - scrollTop <= clientHeight + 5) {

--- a/src/ecrc-frontend/src/components/page/userConfirmation/UserConfirmation.js
+++ b/src/ecrc-frontend/src/components/page/userConfirmation/UserConfirmation.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import React, { useState, useEffect } from "react";
-import { Redirect } from "react-router-dom";
+import { Redirect, useHistory } from "react-router-dom";
 import PropTypes from "prop-types";
 import axios from "axios";
 import Header from "../../base/header/Header";
@@ -15,7 +15,7 @@ import {
 import Loader from "../../base/loader/Loader";
 
 export default function UserConfirmation({ page: { header, setApplicant } }) {
-  const [toConsent, setToConsent] = useState(false);
+  const history = useHistory();
   const [toHome, setToHome] = React.useState(false);
   const [toTransition, setToTransition] = useState(false);
   const [user, setUser] = useState({});
@@ -137,11 +137,7 @@ export default function UserConfirmation({ page: { header, setApplicant } }) {
     generateJWTToken(newPayload);
 
     setApplicant(user);
-    setToConsent(true);
-  }
-
-  if (toConsent) {
-    return <Redirect to="/criminalrecordcheck/userconfirmation" />;
+    history.push("/criminalrecordcheck/userconfirmation");
   }
 
   if (toTransition) {

--- a/src/ecrc-frontend/src/components/page/userConfirmation/UserConfirmation.test.js
+++ b/src/ecrc-frontend/src/components/page/userConfirmation/UserConfirmation.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { create } from "react-test-renderer";
 
 import UserConfirmation from "./UserConfirmation";
+import { MemoryRouter } from "react-router-dom";
 
 describe("User Confirmation Page Component", () => {
   test("Matches the snapshot", () => {
@@ -16,7 +17,11 @@ describe("User Confirmation Page Component", () => {
       setApplicant
     };
 
-    const userConfirmation = create(<UserConfirmation page={page} />);
+    const userConfirmation = create(
+      <MemoryRouter>
+        <UserConfirmation page={page} />
+      </MemoryRouter>
+    );
     expect(userConfirmation.toJSON()).toMatchSnapshot();
   });
 });

--- a/src/ecrc-frontend/src/components/page/userConfirmation/UserConfirmation.test.js
+++ b/src/ecrc-frontend/src/components/page/userConfirmation/UserConfirmation.test.js
@@ -1,8 +1,8 @@
 import React from "react";
 import { create } from "react-test-renderer";
+import { MemoryRouter } from "react-router-dom";
 
 import UserConfirmation from "./UserConfirmation";
-import { MemoryRouter } from "react-router-dom";
 
 describe("User Confirmation Page Component", () => {
   test("Matches the snapshot", () => {

--- a/src/ecrc-frontend/src/index.js
+++ b/src/ecrc-frontend/src/index.js
@@ -5,12 +5,18 @@ import "@bcgov/bootstrap-theme/dist/css/bootstrap-theme.min.css";
 import "./index.css";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
+import { BrowserRouter } from "react-router-dom";
 
 if (process.env.REACT_APP_API_BASE_URL) {
   axios.defaults.baseURL = process.env.REACT_APP_API_BASE_URL;
 }
 
-ReactDOM.render(<App />, document.getElementById("root"));
+ReactDOM.render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>,
+  document.getElementById("root")
+);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/ecrc-frontend/src/index.js
+++ b/src/ecrc-frontend/src/index.js
@@ -2,10 +2,10 @@ import React from "react";
 import ReactDOM from "react-dom";
 import axios from "axios";
 import "@bcgov/bootstrap-theme/dist/css/bootstrap-theme.min.css";
+import { BrowserRouter } from "react-router-dom";
 import "./index.css";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
-import { BrowserRouter } from "react-router-dom";
 
 if (process.env.REACT_APP_API_BASE_URL) {
   axios.defaults.baseURL = process.env.REACT_APP_API_BASE_URL;


### PR DESCRIPTION
# Description

Fixed use of Redirect to history.push for normal page navigation. It still uses Redirect for things like error states and Cancel buttons.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally, some interactions with page protection may need to be looked at for specific use. eg. navigating back past Consent/ToU.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: SPDBCSC-380
