### PR TITLE
SPDBCSC-461: Extracted AES256 secret into properties file.

### DIFF
--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/configuration/EcrcProperties.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/configuration/EcrcProperties.java
@@ -49,6 +49,7 @@ public class EcrcProperties {
 	private String oauthUserinfoPath;
 	private String oauthAuthorizePath;
 	private String oauthWellKnown;
+	private String oauthPERSecret;
 
 	// JWT properties
 	private String jwtHeader;
@@ -305,6 +306,14 @@ public class EcrcProperties {
 
 	public void setOauthWellKnown(String oauthWellKnown) {
 		this.oauthWellKnown = oauthWellKnown;
+	}
+
+	public String getOauthPERSecret() {
+		return oauthPERSecret;
+	}
+
+	public void setOauthPERSecret(String oauthPERSecret) {
+		this.oauthPERSecret = oauthPERSecret;
 	}
 
 }

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/controller/OauthController.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/controller/OauthController.java
@@ -1,16 +1,15 @@
 package ca.bc.gov.open.ecrc.controller;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import net.minidev.json.JSONObject;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.nimbusds.oauth2.sdk.AccessTokenResponse;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
@@ -23,8 +22,7 @@ import ca.bc.gov.open.ecrc.service.OauthServicesImpl;
 import ca.bc.gov.open.ecrc.util.AES256;
 import ca.bc.gov.open.ecrc.util.JwtTokenGenerator;
 import ch.qos.logback.classic.Logger;
-
-import java.util.UUID;
+import net.minidev.json.JSONObject;
 
 /**
  * 
@@ -105,7 +103,7 @@ public class OauthController {
 		// must be decrypted and used for subsequent calls back to the API. 
 	    String encryptedAccessToken = null;
 	    try {
-	    	encryptedAccessToken = AES256.encrypt(token.getTokens().getBearerAccessToken().getValue());
+	    	encryptedAccessToken = AES256.encrypt(token.getTokens().getBearerAccessToken().getValue(), ecrcProps.getOauthPERSecret() );
 		} catch (Exception e) {
 			logger.error("Error encrypting token:", e);
 			return new ResponseEntity(HttpStatus.FORBIDDEN);

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/security/JWTAuthorizationFilter.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/security/JWTAuthorizationFilter.java
@@ -57,7 +57,7 @@ public class JWTAuthorizationFilter  extends OncePerRequestFilter {
                 		// "per" block must be found in private context. 
 	                	if ( claims.get("per") != null ) {
 	                		logger.debug("Found 'PER' claim. Validating....");
-	                		String accessToken = AES256.decrypt((String)claims.get("per")); 
+	                		String accessToken = AES256.decrypt((String)claims.get("per"), ecrcProps.getOauthPERSecret()); 
 	                		if ( accessToken != null ) {
 	                			ValidationResponse resp = tokenValidationServices.validateBCSCAccessToken(accessToken);  
 	                			if ( !resp.isValid() ) {

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/service/ECRCJWTValidationServiceImpl.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/service/ECRCJWTValidationServiceImpl.java
@@ -143,15 +143,15 @@ public class ECRCJWTValidationServiceImpl implements ECRCJWTValidationService {
 
 
 	/**
-	 * Validate the PER claim (Decrypt and validate the BCSC tokens within).
 	 * 
-	 * MIGHT NOT BE USED. 
+	 * Validate the PER claim (Decrypts and validates the BCSC tokens within).
+	 * 
 	 */
 	@Override
 	public ValidationResponse PERValidate(String tokens) {
 		
 		// Decrypt the original claim (labeled "PER") containing the tokens BCSC
-		String _tokens = AES256.decrypt(tokens); 
+		String _tokens = AES256.decrypt(tokens, ecrcProps.getOauthPERSecret()); 
 		JSONParser p = new JSONParser(JSONParser.MODE_RFC4627);
 		JSONObject obj;
 		TokenResponse response = null; 

--- a/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/util/AES256.java
+++ b/src/ecrc-api/src/main/java/ca/bc/gov/open/ecrc/util/AES256.java
@@ -26,23 +26,25 @@ public class AES256 {
 
 	private AES256() { throw new IllegalStateException("Utility class"); }
 
-	private static String secretKey = "@.Rdn4XbG$]%PW2";
 	private static String salt = "p900*gU";
+	
 	private static Logger logger = LoggerFactory.getLogger(AES256.class);
+	
 	/**
 	 * 
-	 * Encrypt
+	 * encrypt
 	 * 
 	 * @param strToEncrypt
+	 * @param secret
 	 * @return
 	 */
-	public static String encrypt(String strToEncrypt) {
+	public static String encrypt(String strToEncrypt, String secret) {
 		try {
 			byte[] iv = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 			IvParameterSpec ivspec = new IvParameterSpec(iv);
 
 			SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
-			KeySpec spec = new PBEKeySpec(secretKey.toCharArray(), salt.getBytes(), 65536, 256);
+			KeySpec spec = new PBEKeySpec(secret.toCharArray(), salt.getBytes(), 65536, 256);
 			SecretKey tmp = factory.generateSecret(spec);
 			SecretKeySpec secretKey = new SecretKeySpec(tmp.getEncoded(), "AES");
 
@@ -54,21 +56,22 @@ public class AES256 {
 		}
 		return null;
 	}
-
+	
 	/**
 	 * 
-	 * Decrypt 
+	 * decrypt
 	 * 
 	 * @param strToDecrypt
+	 * @param secret
 	 * @return
 	 */
-	public static String decrypt(String strToDecrypt) {
+	public static String decrypt(String strToDecrypt, String secret) {
 		try {
 			byte[] iv = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 			IvParameterSpec ivspec = new IvParameterSpec(iv);
 
 			SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
-			KeySpec spec = new PBEKeySpec(secretKey.toCharArray(), salt.getBytes(), 65536, 256);
+			KeySpec spec = new PBEKeySpec(secret.toCharArray(), salt.getBytes(), 65536, 256);
 			SecretKey tmp = factory.generateSecret(spec);
 			SecretKeySpec secretKey = new SecretKeySpec(tmp.getEncoded(), "AES");
 

--- a/src/ecrc-api/src/main/resources/application.properties
+++ b/src/ecrc-api/src/main/resources/application.properties
@@ -77,6 +77,8 @@ ecrc.oauth-return-uri=${ECRC_OAUTH_RETURN_URI}
 ecrc.oauth-userinfo-path=/oauth2/userinfo
 ecrc.oauth-token-path=/oauth2/token
 ecrc.oauth-authorize-path=/login/oidc/authorize
+ecrc.oauth-well-known=${ECRC_OAUTH_WELL_KNOWN}
+ecrc.oauth-per-secret=${ECRC_OAUTH_PER_SECRET}
 
 #JWT token expiry in milliseconds
 ecrc.oauth-jwt-expiry=${ECRC_OAUTH_TOKEN_EXPIRY}

--- a/src/ecrc-api/src/test/java/ca/bc/gov/open/ecrc/util/AES256Test.java
+++ b/src/ecrc-api/src/test/java/ca/bc/gov/open/ecrc/util/AES256Test.java
@@ -1,12 +1,9 @@
 package ca.bc.gov.open.ecrc.util;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import ca.bc.gov.open.ecrc.util.AES256;
 
 /**
  * Tests for AES256 encryption util
@@ -21,22 +18,22 @@ public class AES256Test {
 	@DisplayName("Success - encrypt success, decrypt success")
 	@Test
 	public void testEncryptSuccessDecryptSuccess() {
-		String encryptedString = AES256.encrypt(strToEncrypt);
-		String decryptedString = AES256.decrypt(encryptedString);
+		String encryptedString = AES256.encrypt(strToEncrypt, secret);
+		String decryptedString = AES256.decrypt(encryptedString, secret);
 		assertEquals(decryptedString, strToEncrypt);
 	}
 	
 	@DisplayName("Error - decrypt error")
 	@Test
 	public void testDecryptError() {
-		String decryptedString = AES256.decrypt(null);
+		String decryptedString = AES256.decrypt(null, secret);
 		assertEquals(null, decryptedString);
 	}
 	
 	@DisplayName("Error - encrypt error")
 	@Test
 	public void testEncryptError() {
-		String encryptedString = AES256.encrypt(null);
+		String encryptedString = AES256.encrypt(null, secret);
 		assertEquals(null, encryptedString);
 	}
 	

--- a/src/ecrc-api/src/test/resources/application-test.properties
+++ b/src/ecrc-api/src/test/resources/application-test.properties
@@ -50,6 +50,7 @@ ecrc.oauth-userinfo-path=/test
 ecrc.oauth-token-path=/test
 ecrc.oauth-authorize-path=/test
 ecrc.oauth-well-known=wellknown
+ecrc.oauth-per-secret=secret
 
 #JWT token expiry in milliseconds
 ecrc.oauth-jwt-expiry=3000


### PR DESCRIPTION
# Description

Extracted AES256 secret into properties file. 

NOTE: ONCE MERGED THIS REQUIRES AN ADDITION TO THE OPENSHIFT SECRETS. 
A NEW VALUE IS TO BE ADDED FOR **ECRC_OAUTH_PER_SECRET**.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Ran application and accessed API properly after intial BCSC authorization. 
- Ran unit test suite. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: **SPDBCSC-461**
