### PR TITLE
Fix: Org verification links to open in new tab

### DIFF
--- a/src/ecrc-frontend/.eslintrc.js
+++ b/src/ecrc-frontend/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
     sourceType: "module"
   },
   plugins: ["react", "prettier"],
+  ignorePatterns: ["node_modules/", "build/"],
   rules: {
     "import/no-unresolved": "off",
     "react/jsx-filename-extension": "off",

--- a/src/ecrc-frontend/src/__snapshots__/storyshots.test.js.snap
+++ b/src/ecrc-frontend/src/__snapshots__/storyshots.test.js.snap
@@ -1092,6 +1092,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
+                      target="blank"
                     >
                       Service BC
                     </a>
@@ -1099,6 +1100,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www.icbc.com/Pages/default.aspx"
+                      target="blank"
                     >
                       ICBC
                     </a>
@@ -1106,6 +1108,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www.addresschange.gov.bc.ca/"
+                      target="blank"
                     >
                       AddressChangeBC
                     </a>
@@ -2397,6 +2400,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
+                      target="blank"
                     >
                       Service BC
                     </a>
@@ -2404,6 +2408,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www.icbc.com/Pages/default.aspx"
+                      target="blank"
                     >
                       ICBC
                     </a>
@@ -2411,6 +2416,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www.addresschange.gov.bc.ca/"
+                      target="blank"
                     >
                       AddressChangeBC
                     </a>
@@ -2797,6 +2803,7 @@ exports[`Storyshots BcscRedirect page Default 1`] = `
                     <div>
                       <a
                         href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                        target="blank"
                       >
                         <div
                           className="side-card-link"
@@ -2814,6 +2821,7 @@ exports[`Storyshots BcscRedirect page Default 1`] = `
                     <div>
                       <a
                         href="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/eligibility-and-enrolment/are-you-eligible"
+                        target="blank"
                       >
                         <div
                           className="side-card-link"
@@ -3136,6 +3144,7 @@ exports[`Storyshots BcscRedirect page Mobile 1`] = `
                     <div>
                       <a
                         href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                        target="blank"
                       >
                         <div
                           className="side-card-link"
@@ -3153,6 +3162,7 @@ exports[`Storyshots BcscRedirect page Mobile 1`] = `
                     <div>
                       <a
                         href="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/eligibility-and-enrolment/are-you-eligible"
+                        target="blank"
                       >
                         <div
                           className="side-card-link"
@@ -5572,6 +5582,7 @@ exports[`Storyshots InformationReview Non Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
+                      target="blank"
                     >
                       Service BC
                     </a>
@@ -5579,6 +5590,7 @@ exports[`Storyshots InformationReview Non Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www.icbc.com/Pages/default.aspx"
+                      target="blank"
                     >
                       ICBC
                     </a>
@@ -5586,6 +5598,7 @@ exports[`Storyshots InformationReview Non Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www.addresschange.gov.bc.ca/"
+                      target="blank"
                     >
                       AddressChangeBC
                     </a>
@@ -6125,6 +6138,7 @@ exports[`Storyshots InformationReview Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
+                      target="blank"
                     >
                       Service BC
                     </a>
@@ -6132,6 +6146,7 @@ exports[`Storyshots InformationReview Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www.icbc.com/Pages/default.aspx"
+                      target="blank"
                     >
                       ICBC
                     </a>
@@ -6139,6 +6154,7 @@ exports[`Storyshots InformationReview Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www.addresschange.gov.bc.ca/"
+                      target="blank"
                     >
                       AddressChangeBC
                     </a>
@@ -6290,6 +6306,7 @@ exports[`Storyshots Menu Default 1`] = `
         >
           <a
             href="/"
+            target="blank"
           >
             Home
           </a>
@@ -6299,6 +6316,7 @@ exports[`Storyshots Menu Default 1`] = `
         >
           <a
             href="/somewhere"
+            target="blank"
           >
             Somewhere
           </a>
@@ -6308,6 +6326,7 @@ exports[`Storyshots Menu Default 1`] = `
         >
           <a
             href="/somewhereelse"
+            target="blank"
           >
             Somewhere else
           </a>
@@ -6317,6 +6336,7 @@ exports[`Storyshots Menu Default 1`] = `
         >
           <a
             href="/here"
+            target="blank"
           >
             Somewhere with a long name for no reason
           </a>
@@ -6362,6 +6382,7 @@ exports[`Storyshots Menu Mobile 1`] = `
         >
           <a
             href="/"
+            target="blank"
           >
             Home
           </a>
@@ -6371,6 +6392,7 @@ exports[`Storyshots Menu Mobile 1`] = `
         >
           <a
             href="/somewhere"
+            target="blank"
           >
             Somewhere
           </a>
@@ -6380,6 +6402,7 @@ exports[`Storyshots Menu Mobile 1`] = `
         >
           <a
             href="/somewhereelse"
+            target="blank"
           >
             Somewhere else
           </a>
@@ -6389,6 +6412,7 @@ exports[`Storyshots Menu Mobile 1`] = `
         >
           <a
             href="/here"
+            target="blank"
           >
             Somewhere with a long name for no reason
           </a>
@@ -6405,6 +6429,7 @@ exports[`Storyshots MenuItem Default 1`] = `
 >
   <a
     href="http://www.url.com"
+    target="blank"
   >
     Name
   </a>
@@ -7471,6 +7496,7 @@ Canada
              
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+              target="blank"
             >
               BC Service Card website
             </a>
@@ -7710,6 +7736,7 @@ Canada
                     >
                       <a
                         href="/tbd"
+                        target="blank"
                       >
                         I'm an employee or volunteer
                       </a>
@@ -7719,6 +7746,7 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/electronic-identity-verification-eiv"
+                        target="blank"
                       >
                         Electronic Identity Verification (EIV)
                       </a>
@@ -7728,6 +7756,7 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/results-and-reconsiderations"
+                        target="blank"
                       >
                         Results and Reconsideration
                       </a>
@@ -8158,6 +8187,7 @@ Canada
              
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+              target="blank"
             >
               BC Service Card website
             </a>
@@ -8397,6 +8427,7 @@ Canada
                     >
                       <a
                         href="/tbd"
+                        target="blank"
                       >
                         I'm an employee or volunteer
                       </a>
@@ -8406,6 +8437,7 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/electronic-identity-verification-eiv"
+                        target="blank"
                       >
                         Electronic Identity Verification (EIV)
                       </a>
@@ -8415,6 +8447,7 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/results-and-reconsiderations"
+                        target="blank"
                       >
                         Results and Reconsideration
                       </a>
@@ -8845,6 +8878,7 @@ Canada
              
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+              target="blank"
             >
               BC Service Card website
             </a>
@@ -9084,6 +9118,7 @@ Canada
                     >
                       <a
                         href="/tbd"
+                        target="blank"
                       >
                         I'm an employee or volunteer
                       </a>
@@ -9093,6 +9128,7 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/electronic-identity-verification-eiv"
+                        target="blank"
                       >
                         Electronic Identity Verification (EIV)
                       </a>
@@ -9102,6 +9138,7 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/results-and-reconsiderations"
+                        target="blank"
                       >
                         Results and Reconsideration
                       </a>
@@ -9532,6 +9569,7 @@ Canada
              
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+              target="blank"
             >
               BC Service Card website
             </a>
@@ -9771,6 +9809,7 @@ Canada
                     >
                       <a
                         href="/tbd"
+                        target="blank"
                       >
                         I'm an employee or volunteer
                       </a>
@@ -9780,6 +9819,7 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/electronic-identity-verification-eiv"
+                        target="blank"
                       >
                         Electronic Identity Verification (EIV)
                       </a>
@@ -9789,6 +9829,7 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/results-and-reconsiderations"
+                        target="blank"
                       >
                         Results and Reconsideration
                       </a>
@@ -10331,6 +10372,7 @@ exports[`Storyshots SideCards Bc Service 1`] = `
               <div>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                  target="blank"
                 >
                   <div
                     className="side-card-link"
@@ -10348,6 +10390,7 @@ exports[`Storyshots SideCards Bc Service 1`] = `
               <div>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/eligibility-and-enrolment/are-you-eligible"
+                  target="blank"
                 >
                   <div
                     className="side-card-link"
@@ -10857,6 +10900,7 @@ exports[`Storyshots SideCards Personal Information 1`] = `
               <a
                 className="link"
                 href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
+                target="blank"
               >
                 Service BC
               </a>
@@ -10864,6 +10908,7 @@ exports[`Storyshots SideCards Personal Information 1`] = `
               <a
                 className="link"
                 href="https://www.icbc.com/Pages/default.aspx"
+                target="blank"
               >
                 ICBC
               </a>
@@ -10871,6 +10916,7 @@ exports[`Storyshots SideCards Personal Information 1`] = `
               <a
                 className="link"
                 href="https://www.addresschange.gov.bc.ca/"
+                target="blank"
               >
                 AddressChangeBC
               </a>
@@ -10956,6 +11002,7 @@ exports[`Storyshots SideCards Useful Links 1`] = `
               >
                 <a
                   href="/"
+                  target="blank"
                 >
                   Home
                 </a>
@@ -10965,6 +11012,7 @@ exports[`Storyshots SideCards Useful Links 1`] = `
               >
                 <a
                   href="/somewhere"
+                  target="blank"
                 >
                   Somewhere
                 </a>
@@ -10974,6 +11022,7 @@ exports[`Storyshots SideCards Useful Links 1`] = `
               >
                 <a
                   href="/somewhereelse"
+                  target="blank"
                 >
                   Somewhere else
                 </a>
@@ -10983,6 +11032,7 @@ exports[`Storyshots SideCards Useful Links 1`] = `
               >
                 <a
                   href="/here"
+                  target="blank"
                 >
                   Somewhere with a long name for no reason
                 </a>
@@ -11081,6 +11131,7 @@ exports[`Storyshots SideCards Without BC Service Card 1`] = `
               <div>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                  target="blank"
                 >
                   <div
                     className="side-card-link"

--- a/src/ecrc-frontend/src/components/base/menuItem/MenuItem.js
+++ b/src/ecrc-frontend/src/components/base/menuItem/MenuItem.js
@@ -6,7 +6,9 @@ import "./MenuItem.css";
 export default function MenuItem({ menuItem: { name, url } }) {
   return (
     <li className="menuItem">
-      <a href={url}>{name}</a>
+      <a href={url} target="blank">
+        {name}
+      </a>
     </li>
   );
 }

--- a/src/ecrc-frontend/src/components/base/menuItem/__snapshots__/MenuItem.test.js.snap
+++ b/src/ecrc-frontend/src/components/base/menuItem/__snapshots__/MenuItem.test.js.snap
@@ -6,6 +6,7 @@ exports[`MenuItem Component Matches the snapshot 1`] = `
 >
   <a
     href="/somewhere"
+    target="blank"
   >
     Link to Somewhere
   </a>

--- a/src/ecrc-frontend/src/components/composite/menu/__snapshots__/Menu.test.js.snap
+++ b/src/ecrc-frontend/src/components/composite/menu/__snapshots__/Menu.test.js.snap
@@ -35,6 +35,7 @@ exports[`Menu Component Matches the snapshot of populated menu 1`] = `
         >
           <a
             href="/"
+            target="blank"
           >
             Home
           </a>
@@ -44,6 +45,7 @@ exports[`Menu Component Matches the snapshot of populated menu 1`] = `
         >
           <a
             href="/somewhere"
+            target="blank"
           >
             Somewhere
           </a>
@@ -53,6 +55,7 @@ exports[`Menu Component Matches the snapshot of populated menu 1`] = `
         >
           <a
             href="/somewhereelse"
+            target="blank"
           >
             Somewhere else
           </a>
@@ -62,6 +65,7 @@ exports[`Menu Component Matches the snapshot of populated menu 1`] = `
         >
           <a
             href="/here"
+            target="blank"
           >
             Somewhere with a long name for no reason
           </a>

--- a/src/ecrc-frontend/src/components/composite/sideCards/SideCards.js
+++ b/src/ecrc-frontend/src/components/composite/sideCards/SideCards.js
@@ -86,7 +86,10 @@ export default function SideCards({ type, sideCardLinks }) {
         security verification page.
       </div>,
       <div key="bcscLearnMore">
-        <a href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card">
+        <a
+          href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+          target="blank"
+        >
           <div className="side-card-link">
             Learn more about the BC Services Card.
           </div>
@@ -98,7 +101,10 @@ export default function SideCards({ type, sideCardLinks }) {
         Services Plan(MSP).
       </div>,
       <div key="bcscEligibilityLink">
-        <a href="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/eligibility-and-enrolment/are-you-eligible">
+        <a
+          href="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/eligibility-and-enrolment/are-you-eligible"
+          target="blank"
+        >
           <div className="side-card-link">
             Learn more about BC Services Card eligibility.
           </div>
@@ -203,7 +209,10 @@ export default function SideCards({ type, sideCardLinks }) {
         form.
       </div>,
       <div key="withoutBCSCBottom">
-        <a href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card">
+        <a
+          href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+          target="blank"
+        >
           <div className="side-card-link">
             Learn more about how to apply for a criminal record check offline.
           </div>
@@ -241,6 +250,7 @@ export default function SideCards({ type, sideCardLinks }) {
         key="serviceBC"
         className="link"
         href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
+        target="blank"
       >
         Service BC
       </a>,
@@ -249,6 +259,7 @@ export default function SideCards({ type, sideCardLinks }) {
         key="icbc"
         className="link"
         href="https://www.icbc.com/Pages/default.aspx"
+        target="blank"
       >
         ICBC
       </a>,
@@ -257,6 +268,7 @@ export default function SideCards({ type, sideCardLinks }) {
         key="addressChangeBC"
         className="link"
         href="https://www.addresschange.gov.bc.ca/"
+        target="blank"
       >
         AddressChangeBC
       </a>,

--- a/src/ecrc-frontend/src/components/composite/sideCards/__snapshots__/SideCards.test.js.snap
+++ b/src/ecrc-frontend/src/components/composite/sideCards/__snapshots__/SideCards.test.js.snap
@@ -129,6 +129,7 @@ exports[`SideCards Component AccessCode sidecard 2`] = `
               >
                 <a
                   href="/"
+                  target="blank"
                 >
                   Home
                 </a>
@@ -138,6 +139,7 @@ exports[`SideCards Component AccessCode sidecard 2`] = `
               >
                 <a
                   href="/somewhere"
+                  target="blank"
                 >
                   Somewhere
                 </a>
@@ -147,6 +149,7 @@ exports[`SideCards Component AccessCode sidecard 2`] = `
               >
                 <a
                   href="/somewhereelse"
+                  target="blank"
                 >
                   Somewhere else
                 </a>
@@ -156,6 +159,7 @@ exports[`SideCards Component AccessCode sidecard 2`] = `
               >
                 <a
                   href="/here"
+                  target="blank"
                 >
                   Somewhere with a long name for no reason
                 </a>
@@ -244,6 +248,7 @@ exports[`SideCards Component BcServices sidecard 1`] = `
               <div>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                  target="blank"
                 >
                   <div
                     className="side-card-link"
@@ -261,6 +266,7 @@ exports[`SideCards Component BcServices sidecard 1`] = `
               <div>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/eligibility-and-enrolment/are-you-eligible"
+                  target="blank"
                 >
                   <div
                     className="side-card-link"

--- a/src/ecrc-frontend/src/components/page/applicationForm/__snapshots__/ApplicationForm.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/applicationForm/__snapshots__/ApplicationForm.test.js.snap
@@ -1072,6 +1072,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                       <a
                         class="link"
                         href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
+                        target="blank"
                       >
                         Service BC
                       </a>
@@ -1079,6 +1080,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                       <a
                         class="link"
                         href="https://www.icbc.com/Pages/default.aspx"
+                        target="blank"
                       >
                         ICBC
                       </a>
@@ -1086,6 +1088,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                       <a
                         class="link"
                         href="https://www.addresschange.gov.bc.ca/"
+                        target="blank"
                       >
                         AddressChangeBC
                       </a>

--- a/src/ecrc-frontend/src/components/page/bcscRedirect/__snapshots__/BcscRedirect.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/bcscRedirect/__snapshots__/BcscRedirect.test.js.snap
@@ -200,6 +200,7 @@ exports[`BcscRedirect Page Component Matches the snapshot 1`] = `
                       <div>
                         <a
                           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                          target="blank"
                         >
                           <div
                             class="side-card-link"
@@ -217,6 +218,7 @@ exports[`BcscRedirect Page Component Matches the snapshot 1`] = `
                       <div>
                         <a
                           href="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/eligibility-and-enrolment/are-you-eligible"
+                          target="blank"
                         >
                           <div
                             class="side-card-link"

--- a/src/ecrc-frontend/src/components/page/informationreview/__snapshots__/InformationReview.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/informationreview/__snapshots__/InformationReview.test.js.snap
@@ -540,6 +540,7 @@ exports[`InformationReview Component Matches the snapshot 1`] = `
                     <a
                       className="link"
                       href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
+                      target="blank"
                     >
                       Service BC
                     </a>
@@ -547,6 +548,7 @@ exports[`InformationReview Component Matches the snapshot 1`] = `
                     <a
                       className="link"
                       href="https://www.icbc.com/Pages/default.aspx"
+                      target="blank"
                     >
                       ICBC
                     </a>
@@ -554,6 +556,7 @@ exports[`InformationReview Component Matches the snapshot 1`] = `
                     <a
                       className="link"
                       href="https://www.addresschange.gov.bc.ca/"
+                      target="blank"
                     >
                       AddressChangeBC
                     </a>

--- a/src/ecrc-frontend/src/components/page/orgVerification/OrgVerification.js
+++ b/src/ecrc-frontend/src/components/page/orgVerification/OrgVerification.js
@@ -163,7 +163,10 @@ export default function OrgVerification({ page: { header, org, setError } }) {
               <li>
                 If you do not already have a BC Service Card Account, you can
                 initiate the process at the{" "}
-                <a href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card">
+                <a
+                  href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+                  target="blank"
+                >
                   BC Service Card website
                 </a>
                 .

--- a/src/ecrc-frontend/src/components/page/orgVerification/__snapshots__/OrgVerification.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/orgVerification/__snapshots__/OrgVerification.test.js.snap
@@ -169,6 +169,7 @@ Canada
              
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+              target="blank"
             >
               BC Service Card website
             </a>
@@ -408,6 +409,7 @@ Canada
                     >
                       <a
                         href="/tbd"
+                        target="blank"
                       >
                         I'm an employee or volunteer
                       </a>
@@ -417,6 +419,7 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/electronic-identity-verification-eiv"
+                        target="blank"
                       >
                         Electronic Identity Verification (EIV)
                       </a>
@@ -426,6 +429,7 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/results-and-reconsiderations"
+                        target="blank"
                       >
                         Results and Reconsideration
                       </a>


### PR DESCRIPTION
# Description

Updated links on org verification page and sidecards to open in new tab.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: SPDBCSC-494
