### PR TITLE
Ensure access code not empty, links update

### DIFF
--- a/src/ecrc-frontend/src/__snapshots__/storyshots.test.js.snap
+++ b/src/ecrc-frontend/src/__snapshots__/storyshots.test.js.snap
@@ -103,6 +103,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -133,6 +134,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -163,6 +165,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -212,6 +215,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 onChange={[Function]}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -241,6 +245,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 onChange={[Function]}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -270,6 +275,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 onChange={[Function]}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -323,6 +329,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 placeholder="City, Country"
                 type="text"
               />
+              <br />
               <span
                 className="error"
               >
@@ -355,6 +362,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -385,6 +393,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -416,6 +425,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 onChange={[Function]}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -453,6 +463,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 placeholder="123 456 7890"
                 type="text"
               />
+              <br />
               <span
                 className="error"
               >
@@ -492,6 +503,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 placeholder="example@test.com"
                 type="text"
               />
+              <br />
               <span
                 className="error"
               >
@@ -541,6 +553,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 placeholder="Position/Job Title"
                 type="text"
               />
+              <br />
               <span
                 className="error"
               >
@@ -598,6 +611,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -628,6 +642,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -658,6 +673,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -688,6 +704,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -718,6 +735,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -798,6 +816,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 placeholder="Street or PO Box"
                 type="text"
               />
+              <br />
               <span
                 className="error"
               >
@@ -835,6 +854,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 placeholder="City"
                 type="text"
               />
+              <br />
               <span
                 className="error"
               >
@@ -902,6 +922,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 placeholder="V9V 9V9"
                 type="text"
               />
+              <br />
               <span
                 className="error"
               >
@@ -934,6 +955,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -946,18 +968,21 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
         Entering your mailing address in this application will not update your BC Services Card Address. To update your BC Services Card information you must contact 
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
+          target="_blank"
         >
           Service BC
         </a>
         , 
         <a
           href="https://www.icbc.com/Pages/default.aspx"
+          target="_blank"
         >
           ICBC
         </a>
          or 
         <a
           href="https://www.addresschange.gov.bc.ca/"
+          target="_blank"
         >
           AddressChangeBC
         </a>
@@ -1383,6 +1408,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -1413,6 +1439,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -1443,6 +1470,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -1492,6 +1520,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 onChange={[Function]}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -1521,6 +1550,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 onChange={[Function]}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -1550,6 +1580,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 onChange={[Function]}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -1603,6 +1634,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 placeholder="City, Country"
                 type="text"
               />
+              <br />
               <span
                 className="error"
               >
@@ -1635,6 +1667,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -1665,6 +1698,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -1696,6 +1730,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 onChange={[Function]}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -1733,6 +1768,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 placeholder="123 456 7890"
                 type="text"
               />
+              <br />
               <span
                 className="error"
               >
@@ -1772,6 +1808,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 placeholder="example@test.com"
                 type="text"
               />
+              <br />
               <span
                 className="error"
               >
@@ -1821,6 +1858,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 placeholder="Position/Job Title"
                 type="text"
               />
+              <br />
               <span
                 className="error"
               >
@@ -1860,6 +1898,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 placeholder="Organization Facility"
                 type="text"
               />
+              <br />
               <span
                 className="error"
               >
@@ -1917,6 +1956,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -1947,6 +1987,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -1977,6 +2018,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -2007,6 +2049,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -2037,6 +2080,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -2117,6 +2161,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 placeholder="Street or PO Box"
                 type="text"
               />
+              <br />
               <span
                 className="error"
               >
@@ -2154,6 +2199,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 placeholder="City"
                 type="text"
               />
+              <br />
               <span
                 className="error"
               >
@@ -2221,6 +2267,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 placeholder="V9V 9V9"
                 type="text"
               />
+              <br />
               <span
                 className="error"
               >
@@ -2253,6 +2300,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                 readOnly={true}
                 type="text"
               />
+              <br />
               <span
                 className="error"
               />
@@ -2265,18 +2313,21 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
         Entering your mailing address in this application will not update your BC Services Card Address. To update your BC Services Card information you must contact 
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
+          target="_blank"
         >
           Service BC
         </a>
         , 
         <a
           href="https://www.icbc.com/Pages/default.aspx"
+          target="_blank"
         >
           ICBC
         </a>
          or 
         <a
           href="https://www.addresschange.gov.bc.ca/"
+          target="_blank"
         >
           AddressChangeBC
         </a>
@@ -2670,6 +2721,7 @@ exports[`Storyshots BcscRedirect page Default 1`] = `
          
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+          target="_blank"
         >
           BC Services Card
         </a>
@@ -2682,6 +2734,7 @@ exports[`Storyshots BcscRedirect page Default 1`] = `
          
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+          target="_blank"
         >
           verify your identity
         </a>
@@ -2742,6 +2795,7 @@ exports[`Storyshots BcscRedirect page Default 1`] = `
       >
         <a
           href="/criminalrecordcheck/transition"
+          target="_blank"
         >
           I do not have a BC Services Card, or I have non-photo BC Services Card
         </a>
@@ -3022,6 +3076,7 @@ exports[`Storyshots BcscRedirect page Mobile 1`] = `
          
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+          target="_blank"
         >
           BC Services Card
         </a>
@@ -3034,6 +3089,7 @@ exports[`Storyshots BcscRedirect page Mobile 1`] = `
          
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+          target="_blank"
         >
           verify your identity
         </a>
@@ -3094,6 +3150,7 @@ exports[`Storyshots BcscRedirect page Mobile 1`] = `
       >
         <a
           href="/criminalrecordcheck/transition"
+          target="_blank"
         >
           I do not have a BC Services Card, or I have non-photo BC Services Card
         </a>
@@ -5761,6 +5818,7 @@ exports[`Storyshots FullName Default 1`] = `
           readOnly={true}
           type="text"
         />
+        <br />
         <span
           className="error"
         />
@@ -5791,6 +5849,7 @@ exports[`Storyshots FullName Default 1`] = `
           readOnly={true}
           type="text"
         />
+        <br />
         <span
           className="error"
         />
@@ -5821,6 +5880,7 @@ exports[`Storyshots FullName Default 1`] = `
           readOnly={true}
           type="text"
         />
+        <br />
         <span
           className="error"
         />
@@ -7331,6 +7391,7 @@ exports[`Storyshots OrgValidation Default 1`] = `
            
           <a
             href="http://www.bclaws.ca/EPLibraries/bclaws_new/document/ID/freeside/00_96086_01"
+            target="_blank"
           >
             Criminal Records Review Act (CRRA).
           </a>
@@ -7355,6 +7416,7 @@ exports[`Storyshots OrgValidation Default 1`] = `
                  
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                  target="_blank"
                 >
                   BC Services Card
                 </a>
@@ -7386,6 +7448,7 @@ exports[`Storyshots OrgValidation Default 1`] = `
                   onChange={[Function]}
                   type="text"
                 />
+                <br />
                 <span
                   className="error"
                 >
@@ -7446,13 +7509,16 @@ exports[`Storyshots OrgValidation Default 1`] = `
               <li>
                 <a
                   href="volunteer"
+                  target="_blank"
                 >
                   I'm an employee or a volunteer
                 </a>
-                 and I want to know
+                 
+                and I want to know
                  
                 <a
                   href="http://www.rcmp-grc.gc.ca/en/types-criminal-background-checks"
+                  target="_blank"
                 >
                   why I need to apply for a criminal record check
                 </a>
@@ -7460,6 +7526,7 @@ exports[`Storyshots OrgValidation Default 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                  target="_blank"
                 >
                   I don't have a BC Services Card
                 </a>
@@ -7467,6 +7534,7 @@ exports[`Storyshots OrgValidation Default 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/organization-registration/employee-organization-registration/employee-contact-registration"
+                  target="_blank"
                 >
                   I'm an authorized contact
                 </a>
@@ -7476,6 +7544,7 @@ exports[`Storyshots OrgValidation Default 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/employer-organizations"
+                  target="_blank"
                 >
                   I'm an employer organization
                 </a>
@@ -7485,6 +7554,7 @@ exports[`Storyshots OrgValidation Default 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/volunteer-organizations"
+                  target="_blank"
                 >
                   I'm a volunteer organization
                 </a>
@@ -7680,6 +7750,7 @@ exports[`Storyshots OrgValidation Mobile 1`] = `
            
           <a
             href="http://www.bclaws.ca/EPLibraries/bclaws_new/document/ID/freeside/00_96086_01"
+            target="_blank"
           >
             Criminal Records Review Act (CRRA).
           </a>
@@ -7704,6 +7775,7 @@ exports[`Storyshots OrgValidation Mobile 1`] = `
                  
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                  target="_blank"
                 >
                   BC Services Card
                 </a>
@@ -7735,6 +7807,7 @@ exports[`Storyshots OrgValidation Mobile 1`] = `
                   onChange={[Function]}
                   type="text"
                 />
+                <br />
                 <span
                   className="error"
                 >
@@ -7795,13 +7868,16 @@ exports[`Storyshots OrgValidation Mobile 1`] = `
               <li>
                 <a
                   href="volunteer"
+                  target="_blank"
                 >
                   I'm an employee or a volunteer
                 </a>
-                 and I want to know
+                 
+                and I want to know
                  
                 <a
                   href="http://www.rcmp-grc.gc.ca/en/types-criminal-background-checks"
+                  target="_blank"
                 >
                   why I need to apply for a criminal record check
                 </a>
@@ -7809,6 +7885,7 @@ exports[`Storyshots OrgValidation Mobile 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                  target="_blank"
                 >
                   I don't have a BC Services Card
                 </a>
@@ -7816,6 +7893,7 @@ exports[`Storyshots OrgValidation Mobile 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/organization-registration/employee-organization-registration/employee-contact-registration"
+                  target="_blank"
                 >
                   I'm an authorized contact
                 </a>
@@ -7825,6 +7903,7 @@ exports[`Storyshots OrgValidation Mobile 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/employer-organizations"
+                  target="_blank"
                 >
                   I'm an employer organization
                 </a>
@@ -7834,6 +7913,7 @@ exports[`Storyshots OrgValidation Mobile 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/volunteer-organizations"
+                  target="_blank"
                 >
                   I'm a volunteer organization
                 </a>
@@ -7968,6 +8048,7 @@ exports[`Storyshots OrgValidationText Default 1`] = `
      
     <a
       href="http://www.bclaws.ca/EPLibraries/bclaws_new/document/ID/freeside/00_96086_01"
+      target="_blank"
     >
       Criminal Records Review Act (CRRA).
     </a>
@@ -7992,6 +8073,7 @@ exports[`Storyshots OrgValidationText Default 1`] = `
            
           <a
             href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+            target="_blank"
           >
             BC Services Card
           </a>
@@ -8043,6 +8125,7 @@ exports[`Storyshots OrgValidationText Default 1`] = `
             onChange={[Function]}
             type="text"
           />
+          <br />
           <span
             className="error"
           />
@@ -8100,13 +8183,16 @@ exports[`Storyshots OrgValidationText Default 1`] = `
         <li>
           <a
             href="volunteer"
+            target="_blank"
           >
             I'm an employee or a volunteer
           </a>
-           and I want to know
+           
+          and I want to know
            
           <a
             href="http://www.rcmp-grc.gc.ca/en/types-criminal-background-checks"
+            target="_blank"
           >
             why I need to apply for a criminal record check
           </a>
@@ -8114,6 +8200,7 @@ exports[`Storyshots OrgValidationText Default 1`] = `
         <li>
           <a
             href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+            target="_blank"
           >
             I don't have a BC Services Card
           </a>
@@ -8121,6 +8208,7 @@ exports[`Storyshots OrgValidationText Default 1`] = `
         <li>
           <a
             href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/organization-registration/employee-organization-registration/employee-contact-registration"
+            target="_blank"
           >
             I'm an authorized contact
           </a>
@@ -8130,6 +8218,7 @@ exports[`Storyshots OrgValidationText Default 1`] = `
         <li>
           <a
             href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/employer-organizations"
+            target="_blank"
           >
             I'm an employer organization
           </a>
@@ -8139,6 +8228,7 @@ exports[`Storyshots OrgValidationText Default 1`] = `
         <li>
           <a
             href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/volunteer-organizations"
+            target="_blank"
           >
             I'm a volunteer organization
           </a>
@@ -12066,6 +12156,7 @@ exports[`Storyshots SimpleForm 3texts_3buttons 1`] = `
           onChange={[Function]}
           type="text"
         />
+        <br />
         <span
           className="error"
         />
@@ -12096,6 +12187,7 @@ exports[`Storyshots SimpleForm 3texts_3buttons 1`] = `
           readOnly={true}
           type="text"
         />
+        <br />
         <span
           className="error"
         />
@@ -12129,6 +12221,7 @@ exports[`Storyshots SimpleForm 3texts_3buttons 1`] = `
           onChange={[Function]}
           type="text"
         />
+        <br />
         <span
           className="error"
         />
@@ -12223,6 +12316,7 @@ exports[`Storyshots SimpleForm Title_3texts_3buttons 1`] = `
           onChange={[Function]}
           type="text"
         />
+        <br />
         <span
           className="error"
         />
@@ -12253,6 +12347,7 @@ exports[`Storyshots SimpleForm Title_3texts_3buttons 1`] = `
           readOnly={true}
           type="text"
         />
+        <br />
         <span
           className="error"
         />
@@ -12286,6 +12381,7 @@ exports[`Storyshots SimpleForm Title_3texts_3buttons 1`] = `
           onChange={[Function]}
           type="text"
         />
+        <br />
         <span
           className="error"
         />
@@ -16270,6 +16366,7 @@ exports[`Storyshots TextInput Default 1`] = `
     onChange={[Function]}
     type="text"
   />
+  <br />
   <span
     className="error"
   />
@@ -16305,6 +16402,7 @@ exports[`Storyshots TextInput editable-gray-required 1`] = `
     onChange={[Function]}
     type="text"
   />
+  <br />
   <span
     className="error"
   />
@@ -16340,6 +16438,7 @@ exports[`Storyshots TextInput editable-white-required 1`] = `
     onChange={[Function]}
     type="text"
   />
+  <br />
   <span
     className="error"
   />
@@ -16369,6 +16468,7 @@ exports[`Storyshots TextInput error 1`] = `
     onChange={[Function]}
     type="text"
   />
+  <br />
   <span
     className="error"
   >
@@ -16402,6 +16502,7 @@ exports[`Storyshots TextInput non-editable-gray 1`] = `
     readOnly={true}
     type="text"
   />
+  <br />
   <span
     className="error"
   />
@@ -16433,6 +16534,7 @@ exports[`Storyshots TextInput note 1`] = `
     onChange={[Function]}
     type="text"
   />
+  <br />
   <span
     className="error"
   />
@@ -16850,6 +16952,7 @@ exports[`Storyshots Transition Page Not Whitelisted 1`] = `
          
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+          target="_blank"
         >
           BC Services Card account
         </a>

--- a/src/ecrc-frontend/src/__snapshots__/storyshots.test.js.snap
+++ b/src/ecrc-frontend/src/__snapshots__/storyshots.test.js.snap
@@ -968,6 +968,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
         Entering your mailing address in this application will not update your BC Services Card Address. To update your BC Services Card information you must contact 
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
+          rel="noopener noreferrer"
           target="_blank"
         >
           Service BC
@@ -975,6 +976,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
         , 
         <a
           href="https://www.icbc.com/Pages/default.aspx"
+          rel="noopener noreferrer"
           target="_blank"
         >
           ICBC
@@ -982,6 +984,7 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
          or 
         <a
           href="https://www.addresschange.gov.bc.ca/"
+          rel="noopener noreferrer"
           target="_blank"
         >
           AddressChangeBC
@@ -1117,7 +1120,8 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
-                      target="blank"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       Service BC
                     </a>
@@ -1125,7 +1129,8 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www.icbc.com/Pages/default.aspx"
-                      target="blank"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       ICBC
                     </a>
@@ -1133,7 +1138,8 @@ exports[`Storyshots ApplicationForm Non Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www.addresschange.gov.bc.ca/"
-                      target="blank"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       AddressChangeBC
                     </a>
@@ -2313,6 +2319,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
         Entering your mailing address in this application will not update your BC Services Card Address. To update your BC Services Card information you must contact 
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
+          rel="noopener noreferrer"
           target="_blank"
         >
           Service BC
@@ -2320,6 +2327,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
         , 
         <a
           href="https://www.icbc.com/Pages/default.aspx"
+          rel="noopener noreferrer"
           target="_blank"
         >
           ICBC
@@ -2327,6 +2335,7 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
          or 
         <a
           href="https://www.addresschange.gov.bc.ca/"
+          rel="noopener noreferrer"
           target="_blank"
         >
           AddressChangeBC
@@ -2462,7 +2471,8 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
-                      target="blank"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       Service BC
                     </a>
@@ -2470,7 +2480,8 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www.icbc.com/Pages/default.aspx"
-                      target="blank"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       ICBC
                     </a>
@@ -2478,7 +2489,8 @@ exports[`Storyshots ApplicationForm Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www.addresschange.gov.bc.ca/"
-                      target="blank"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       AddressChangeBC
                     </a>
@@ -2721,6 +2733,7 @@ exports[`Storyshots BcscRedirect page Default 1`] = `
          
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+          rel="noopener noreferrer"
           target="_blank"
         >
           BC Services Card
@@ -2734,6 +2747,7 @@ exports[`Storyshots BcscRedirect page Default 1`] = `
          
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+          rel="noopener noreferrer"
           target="_blank"
         >
           verify your identity
@@ -2879,7 +2893,8 @@ exports[`Storyshots BcscRedirect page Default 1`] = `
                     <div>
                       <a
                         href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         <div
                           className="side-card-link"
@@ -2897,7 +2912,8 @@ exports[`Storyshots BcscRedirect page Default 1`] = `
                     <div>
                       <a
                         href="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/eligibility-and-enrolment/are-you-eligible"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         <div
                           className="side-card-link"
@@ -3076,6 +3092,7 @@ exports[`Storyshots BcscRedirect page Mobile 1`] = `
          
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+          rel="noopener noreferrer"
           target="_blank"
         >
           BC Services Card
@@ -3089,6 +3106,7 @@ exports[`Storyshots BcscRedirect page Mobile 1`] = `
          
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+          rel="noopener noreferrer"
           target="_blank"
         >
           verify your identity
@@ -3234,7 +3252,8 @@ exports[`Storyshots BcscRedirect page Mobile 1`] = `
                     <div>
                       <a
                         href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         <div
                           className="side-card-link"
@@ -3252,7 +3271,8 @@ exports[`Storyshots BcscRedirect page Mobile 1`] = `
                     <div>
                       <a
                         href="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/eligibility-and-enrolment/are-you-eligible"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         <div
                           className="side-card-link"
@@ -6443,7 +6463,8 @@ exports[`Storyshots InformationReview Non Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
-                      target="blank"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       Service BC
                     </a>
@@ -6451,7 +6472,8 @@ exports[`Storyshots InformationReview Non Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www.icbc.com/Pages/default.aspx"
-                      target="blank"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       ICBC
                     </a>
@@ -6459,7 +6481,8 @@ exports[`Storyshots InformationReview Non Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www.addresschange.gov.bc.ca/"
-                      target="blank"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       AddressChangeBC
                     </a>
@@ -7010,7 +7033,8 @@ exports[`Storyshots InformationReview Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
-                      target="blank"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       Service BC
                     </a>
@@ -7018,7 +7042,8 @@ exports[`Storyshots InformationReview Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www.icbc.com/Pages/default.aspx"
-                      target="blank"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       ICBC
                     </a>
@@ -7026,7 +7051,8 @@ exports[`Storyshots InformationReview Schedule D 1`] = `
                     <a
                       className="link"
                       href="https://www.addresschange.gov.bc.ca/"
-                      target="blank"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       AddressChangeBC
                     </a>
@@ -7189,7 +7215,8 @@ exports[`Storyshots Menu Default 1`] = `
         >
           <a
             href="/"
-            target="blank"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Home
           </a>
@@ -7199,7 +7226,8 @@ exports[`Storyshots Menu Default 1`] = `
         >
           <a
             href="/somewhere"
-            target="blank"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Somewhere
           </a>
@@ -7209,7 +7237,8 @@ exports[`Storyshots Menu Default 1`] = `
         >
           <a
             href="/somewhereelse"
-            target="blank"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Somewhere else
           </a>
@@ -7219,7 +7248,8 @@ exports[`Storyshots Menu Default 1`] = `
         >
           <a
             href="/here"
-            target="blank"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Somewhere with a long name for no reason
           </a>
@@ -7265,7 +7295,8 @@ exports[`Storyshots Menu Mobile 1`] = `
         >
           <a
             href="/"
-            target="blank"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Home
           </a>
@@ -7275,7 +7306,8 @@ exports[`Storyshots Menu Mobile 1`] = `
         >
           <a
             href="/somewhere"
-            target="blank"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Somewhere
           </a>
@@ -7285,7 +7317,8 @@ exports[`Storyshots Menu Mobile 1`] = `
         >
           <a
             href="/somewhereelse"
-            target="blank"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Somewhere else
           </a>
@@ -7295,7 +7328,8 @@ exports[`Storyshots Menu Mobile 1`] = `
         >
           <a
             href="/here"
-            target="blank"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Somewhere with a long name for no reason
           </a>
@@ -7312,7 +7346,8 @@ exports[`Storyshots MenuItem Default 1`] = `
 >
   <a
     href="http://www.url.com"
-    target="blank"
+    rel="noopener noreferrer"
+    target="_blank"
   >
     Name
   </a>
@@ -7391,6 +7426,7 @@ exports[`Storyshots OrgValidation Default 1`] = `
            
           <a
             href="http://www.bclaws.ca/EPLibraries/bclaws_new/document/ID/freeside/00_96086_01"
+            rel="noopener noreferrer"
             target="_blank"
           >
             Criminal Records Review Act (CRRA).
@@ -7416,6 +7452,7 @@ exports[`Storyshots OrgValidation Default 1`] = `
                  
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   BC Services Card
@@ -7518,6 +7555,7 @@ exports[`Storyshots OrgValidation Default 1`] = `
                  
                 <a
                   href="http://www.rcmp-grc.gc.ca/en/types-criminal-background-checks"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   why I need to apply for a criminal record check
@@ -7526,6 +7564,7 @@ exports[`Storyshots OrgValidation Default 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   I don't have a BC Services Card
@@ -7534,6 +7573,7 @@ exports[`Storyshots OrgValidation Default 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/organization-registration/employee-organization-registration/employee-contact-registration"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   I'm an authorized contact
@@ -7544,6 +7584,7 @@ exports[`Storyshots OrgValidation Default 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/employer-organizations"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   I'm an employer organization
@@ -7554,6 +7595,7 @@ exports[`Storyshots OrgValidation Default 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/volunteer-organizations"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   I'm a volunteer organization
@@ -7750,6 +7792,7 @@ exports[`Storyshots OrgValidation Mobile 1`] = `
            
           <a
             href="http://www.bclaws.ca/EPLibraries/bclaws_new/document/ID/freeside/00_96086_01"
+            rel="noopener noreferrer"
             target="_blank"
           >
             Criminal Records Review Act (CRRA).
@@ -7775,6 +7818,7 @@ exports[`Storyshots OrgValidation Mobile 1`] = `
                  
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   BC Services Card
@@ -7877,6 +7921,7 @@ exports[`Storyshots OrgValidation Mobile 1`] = `
                  
                 <a
                   href="http://www.rcmp-grc.gc.ca/en/types-criminal-background-checks"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   why I need to apply for a criminal record check
@@ -7885,6 +7930,7 @@ exports[`Storyshots OrgValidation Mobile 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   I don't have a BC Services Card
@@ -7893,6 +7939,7 @@ exports[`Storyshots OrgValidation Mobile 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/organization-registration/employee-organization-registration/employee-contact-registration"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   I'm an authorized contact
@@ -7903,6 +7950,7 @@ exports[`Storyshots OrgValidation Mobile 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/employer-organizations"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   I'm an employer organization
@@ -7913,6 +7961,7 @@ exports[`Storyshots OrgValidation Mobile 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/volunteer-organizations"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   I'm a volunteer organization
@@ -8048,6 +8097,7 @@ exports[`Storyshots OrgValidationText Default 1`] = `
      
     <a
       href="http://www.bclaws.ca/EPLibraries/bclaws_new/document/ID/freeside/00_96086_01"
+      rel="noopener noreferrer"
       target="_blank"
     >
       Criminal Records Review Act (CRRA).
@@ -8073,6 +8123,7 @@ exports[`Storyshots OrgValidationText Default 1`] = `
            
           <a
             href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+            rel="noopener noreferrer"
             target="_blank"
           >
             BC Services Card
@@ -8192,6 +8243,7 @@ exports[`Storyshots OrgValidationText Default 1`] = `
            
           <a
             href="http://www.rcmp-grc.gc.ca/en/types-criminal-background-checks"
+            rel="noopener noreferrer"
             target="_blank"
           >
             why I need to apply for a criminal record check
@@ -8200,6 +8252,7 @@ exports[`Storyshots OrgValidationText Default 1`] = `
         <li>
           <a
             href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+            rel="noopener noreferrer"
             target="_blank"
           >
             I don't have a BC Services Card
@@ -8208,6 +8261,7 @@ exports[`Storyshots OrgValidationText Default 1`] = `
         <li>
           <a
             href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/organization-registration/employee-organization-registration/employee-contact-registration"
+            rel="noopener noreferrer"
             target="_blank"
           >
             I'm an authorized contact
@@ -8218,6 +8272,7 @@ exports[`Storyshots OrgValidationText Default 1`] = `
         <li>
           <a
             href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/employer-organizations"
+            rel="noopener noreferrer"
             target="_blank"
           >
             I'm an employer organization
@@ -8228,6 +8283,7 @@ exports[`Storyshots OrgValidationText Default 1`] = `
         <li>
           <a
             href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/volunteer-organizations"
+            rel="noopener noreferrer"
             target="_blank"
           >
             I'm a volunteer organization
@@ -8431,7 +8487,8 @@ Canada
              
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
-              target="blank"
+              rel="noopener noreferrer"
+              target="_blank"
             >
               BC Service Card website
             </a>
@@ -8671,7 +8728,8 @@ Canada
                     >
                       <a
                         href="/tbd"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         I'm an employee or volunteer
                       </a>
@@ -8681,7 +8739,8 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/electronic-identity-verification-eiv"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         Electronic Identity Verification (EIV)
                       </a>
@@ -8691,7 +8750,8 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/results-and-reconsiderations"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         Results and Reconsideration
                       </a>
@@ -9133,7 +9193,8 @@ Canada
              
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
-              target="blank"
+              rel="noopener noreferrer"
+              target="_blank"
             >
               BC Service Card website
             </a>
@@ -9373,7 +9434,8 @@ Canada
                     >
                       <a
                         href="/tbd"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         I'm an employee or volunteer
                       </a>
@@ -9383,7 +9445,8 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/electronic-identity-verification-eiv"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         Electronic Identity Verification (EIV)
                       </a>
@@ -9393,7 +9456,8 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/results-and-reconsiderations"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         Results and Reconsideration
                       </a>
@@ -9835,7 +9899,8 @@ Canada
              
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
-              target="blank"
+              rel="noopener noreferrer"
+              target="_blank"
             >
               BC Service Card website
             </a>
@@ -10075,7 +10140,8 @@ Canada
                     >
                       <a
                         href="/tbd"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         I'm an employee or volunteer
                       </a>
@@ -10085,7 +10151,8 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/electronic-identity-verification-eiv"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         Electronic Identity Verification (EIV)
                       </a>
@@ -10095,7 +10162,8 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/results-and-reconsiderations"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         Results and Reconsideration
                       </a>
@@ -10537,7 +10605,8 @@ Canada
              
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
-              target="blank"
+              rel="noopener noreferrer"
+              target="_blank"
             >
               BC Service Card website
             </a>
@@ -10777,7 +10846,8 @@ Canada
                     >
                       <a
                         href="/tbd"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         I'm an employee or volunteer
                       </a>
@@ -10787,7 +10857,8 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/electronic-identity-verification-eiv"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         Electronic Identity Verification (EIV)
                       </a>
@@ -10797,7 +10868,8 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/results-and-reconsiderations"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         Results and Reconsideration
                       </a>
@@ -11351,7 +11423,8 @@ exports[`Storyshots SideCards Bc Service 1`] = `
               <div>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
-                  target="blank"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
                   <div
                     className="side-card-link"
@@ -11369,7 +11442,8 @@ exports[`Storyshots SideCards Bc Service 1`] = `
               <div>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/eligibility-and-enrolment/are-you-eligible"
-                  target="blank"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
                   <div
                     className="side-card-link"
@@ -11879,7 +11953,8 @@ exports[`Storyshots SideCards Personal Information 1`] = `
               <a
                 className="link"
                 href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
-                target="blank"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 Service BC
               </a>
@@ -11887,7 +11962,8 @@ exports[`Storyshots SideCards Personal Information 1`] = `
               <a
                 className="link"
                 href="https://www.icbc.com/Pages/default.aspx"
-                target="blank"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 ICBC
               </a>
@@ -11895,7 +11971,8 @@ exports[`Storyshots SideCards Personal Information 1`] = `
               <a
                 className="link"
                 href="https://www.addresschange.gov.bc.ca/"
-                target="blank"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 AddressChangeBC
               </a>
@@ -11981,7 +12058,8 @@ exports[`Storyshots SideCards Useful Links 1`] = `
               >
                 <a
                   href="/"
-                  target="blank"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
                   Home
                 </a>
@@ -11991,7 +12069,8 @@ exports[`Storyshots SideCards Useful Links 1`] = `
               >
                 <a
                   href="/somewhere"
-                  target="blank"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
                   Somewhere
                 </a>
@@ -12001,7 +12080,8 @@ exports[`Storyshots SideCards Useful Links 1`] = `
               >
                 <a
                   href="/somewhereelse"
-                  target="blank"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
                   Somewhere else
                 </a>
@@ -12011,7 +12091,8 @@ exports[`Storyshots SideCards Useful Links 1`] = `
               >
                 <a
                   href="/here"
-                  target="blank"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
                   Somewhere with a long name for no reason
                 </a>
@@ -12110,7 +12191,8 @@ exports[`Storyshots SideCards Without BC Service Card 1`] = `
               <div>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
-                  target="blank"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
                   <div
                     className="side-card-link"
@@ -14297,7 +14379,7 @@ exports[`Storyshots Term Of Use page Default 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/home/privacy"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 Privacy Policy
               </a>
@@ -14325,7 +14407,7 @@ exports[`Storyshots Term Of Use page Default 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 BC Services Card
               </a>
@@ -14338,7 +14420,7 @@ exports[`Storyshots Term Of Use page Default 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 BC Services Card Site
               </a>
@@ -14464,7 +14546,7 @@ exports[`Storyshots Term Of Use page Default 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/home/disclaimer"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 Limitation of Liabilities
               </a>
@@ -14554,7 +14636,7 @@ exports[`Storyshots Term Of Use page Default 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/home/privacy"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 Privacy Policy
               </a>
@@ -14582,7 +14664,7 @@ exports[`Storyshots Term Of Use page Default 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 BC Services Card
               </a>
@@ -14595,7 +14677,7 @@ exports[`Storyshots Term Of Use page Default 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 BC Services Card Site
               </a>
@@ -14721,7 +14803,7 @@ exports[`Storyshots Term Of Use page Default 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/home/disclaimer"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 Limitation of Liabilities
               </a>
@@ -15095,7 +15177,7 @@ exports[`Storyshots Term Of Use page Mobile 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/home/privacy"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 Privacy Policy
               </a>
@@ -15123,7 +15205,7 @@ exports[`Storyshots Term Of Use page Mobile 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 BC Services Card
               </a>
@@ -15136,7 +15218,7 @@ exports[`Storyshots Term Of Use page Mobile 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 BC Services Card Site
               </a>
@@ -15262,7 +15344,7 @@ exports[`Storyshots Term Of Use page Mobile 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/home/disclaimer"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 Limitation of Liabilities
               </a>
@@ -15352,7 +15434,7 @@ exports[`Storyshots Term Of Use page Mobile 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/home/privacy"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 Privacy Policy
               </a>
@@ -15380,7 +15462,7 @@ exports[`Storyshots Term Of Use page Mobile 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 BC Services Card
               </a>
@@ -15393,7 +15475,7 @@ exports[`Storyshots Term Of Use page Mobile 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 BC Services Card Site
               </a>
@@ -15519,7 +15601,7 @@ exports[`Storyshots Term Of Use page Mobile 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/home/disclaimer"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 Limitation of Liabilities
               </a>
@@ -15832,7 +15914,7 @@ exports[`Storyshots Terms of Use Default 1`] = `
         <a
           href="https://www2.gov.bc.ca/gov/content/home/privacy"
           rel="noopener noreferrer"
-          target="blank"
+          target="_blank"
         >
           Privacy Policy
         </a>
@@ -15860,7 +15942,7 @@ exports[`Storyshots Terms of Use Default 1`] = `
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
           rel="noopener noreferrer"
-          target="blank"
+          target="_blank"
         >
           BC Services Card
         </a>
@@ -15873,7 +15955,7 @@ exports[`Storyshots Terms of Use Default 1`] = `
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
           rel="noopener noreferrer"
-          target="blank"
+          target="_blank"
         >
           BC Services Card Site
         </a>
@@ -15999,7 +16081,7 @@ exports[`Storyshots Terms of Use Default 1`] = `
         <a
           href="https://www2.gov.bc.ca/gov/content/home/disclaimer"
           rel="noopener noreferrer"
-          target="blank"
+          target="_blank"
         >
           Limitation of Liabilities
         </a>
@@ -16089,7 +16171,7 @@ exports[`Storyshots Terms of Use Default 1`] = `
         <a
           href="https://www2.gov.bc.ca/gov/content/home/privacy"
           rel="noopener noreferrer"
-          target="blank"
+          target="_blank"
         >
           Privacy Policy
         </a>
@@ -16117,7 +16199,7 @@ exports[`Storyshots Terms of Use Default 1`] = `
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
           rel="noopener noreferrer"
-          target="blank"
+          target="_blank"
         >
           BC Services Card
         </a>
@@ -16130,7 +16212,7 @@ exports[`Storyshots Terms of Use Default 1`] = `
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
           rel="noopener noreferrer"
-          target="blank"
+          target="_blank"
         >
           BC Services Card Site
         </a>
@@ -16256,7 +16338,7 @@ exports[`Storyshots Terms of Use Default 1`] = `
         <a
           href="https://www2.gov.bc.ca/gov/content/home/disclaimer"
           rel="noopener noreferrer"
-          target="blank"
+          target="_blank"
         >
           Limitation of Liabilities
         </a>
@@ -16952,6 +17034,7 @@ exports[`Storyshots Transition Page Not Whitelisted 1`] = `
          
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+          rel="noopener noreferrer"
           target="_blank"
         >
           BC Services Card account

--- a/src/ecrc-frontend/src/components/base/menuItem/MenuItem.js
+++ b/src/ecrc-frontend/src/components/base/menuItem/MenuItem.js
@@ -6,7 +6,7 @@ import "./MenuItem.css";
 export default function MenuItem({ menuItem: { name, url } }) {
   return (
     <li className="menuItem">
-      <a href={url} target="blank">
+      <a href={url} target="_blank" rel="noopener noreferrer">
         {name}
       </a>
     </li>

--- a/src/ecrc-frontend/src/components/base/menuItem/__snapshots__/MenuItem.test.js.snap
+++ b/src/ecrc-frontend/src/components/base/menuItem/__snapshots__/MenuItem.test.js.snap
@@ -6,7 +6,8 @@ exports[`MenuItem Component Matches the snapshot 1`] = `
 >
   <a
     href="/somewhere"
-    target="blank"
+    rel="noopener noreferrer"
+    target="_blank"
   >
     Link to Somewhere
   </a>

--- a/src/ecrc-frontend/src/components/base/orgValidationText/OrgValidationText.js
+++ b/src/ecrc-frontend/src/components/base/orgValidationText/OrgValidationText.js
@@ -24,6 +24,7 @@ export default function OrgValidationText({
         <a
           href="http://www.bclaws.ca/EPLibraries/bclaws_new/document/ID/freeside/00_96086_01"
           target="_blank"
+          rel="noopener noreferrer"
         >
           Criminal Records Review Act (CRRA).
         </a>
@@ -42,6 +43,7 @@ export default function OrgValidationText({
               <a
                 href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 BC Services Card
               </a>{" "}
@@ -86,6 +88,7 @@ export default function OrgValidationText({
               <a
                 href="http://www.rcmp-grc.gc.ca/en/types-criminal-background-checks"
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 why I need to apply for a criminal record check
               </a>
@@ -94,6 +97,7 @@ export default function OrgValidationText({
               <a
                 href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 I don&apos;t have a BC Services Card
               </a>
@@ -102,6 +106,7 @@ export default function OrgValidationText({
               <a
                 href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/organization-registration/employee-organization-registration/employee-contact-registration"
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 {"I'm an authorized contact"}
               </a>{" "}
@@ -112,6 +117,7 @@ export default function OrgValidationText({
               <a
                 href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/employer-organizations"
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 {"I'm an employer organization"}
               </a>{" "}
@@ -122,6 +128,7 @@ export default function OrgValidationText({
               <a
                 href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/volunteer-organizations"
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 {"I'm a volunteer organization"}
               </a>{" "}

--- a/src/ecrc-frontend/src/components/base/orgValidationText/OrgValidationText.js
+++ b/src/ecrc-frontend/src/components/base/orgValidationText/OrgValidationText.js
@@ -21,7 +21,10 @@ export default function OrgValidationText({
         potential for unsupervised access to children and/or vulnerable adults,
         you are required to complete a criminal record check. This portal
         enables you to easily apply for a criminal record check under the{" "}
-        <a href="http://www.bclaws.ca/EPLibraries/bclaws_new/document/ID/freeside/00_96086_01">
+        <a
+          href="http://www.bclaws.ca/EPLibraries/bclaws_new/document/ID/freeside/00_96086_01"
+          target="_blank"
+        >
           Criminal Records Review Act (CRRA).
         </a>
       </p>
@@ -36,7 +39,10 @@ export default function OrgValidationText({
             <li>{"Be at least 12 years of age as of today's date"}</li>
             <li>
               Have your identity verified by using your{" "}
-              <a href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card">
+              <a
+                href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                target="_blank"
+              >
                 BC Services Card
               </a>{" "}
               (BCSC). The BCSC provides secure access to provincial government
@@ -73,33 +79,50 @@ export default function OrgValidationText({
           <h3>I need more information</h3>
           <ul className="bodyList">
             <li>
-              <a href="volunteer">{"I'm an employee or a volunteer"}</a> and I
-              want to know{" "}
-              <a href="http://www.rcmp-grc.gc.ca/en/types-criminal-background-checks">
+              <a href="volunteer" target="_blank">
+                {"I'm an employee or a volunteer"}
+              </a>{" "}
+              and I want to know{" "}
+              <a
+                href="http://www.rcmp-grc.gc.ca/en/types-criminal-background-checks"
+                target="_blank"
+              >
                 why I need to apply for a criminal record check
               </a>
             </li>
             <li>
-              <a href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card">
+              <a
+                href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                target="_blank"
+              >
                 I don&apos;t have a BC Services Card
               </a>
             </li>
             <li>
-              <a href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/organization-registration/employee-organization-registration/employee-contact-registration">
+              <a
+                href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/organization-registration/employee-organization-registration/employee-contact-registration"
+                target="_blank"
+              >
                 {"I'm an authorized contact"}
               </a>{" "}
               who is responsible for facilitating the criminal record check for
               my organization
             </li>
             <li>
-              <a href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/employer-organizations">
+              <a
+                href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/employer-organizations"
+                target="_blank"
+              >
                 {"I'm an employer organization"}
               </a>{" "}
               and I want to learn more about registering with the Criminal
               Records Review Program (CRRP)
             </li>
             <li>
-              <a href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/volunteer-organizations">
+              <a
+                href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/volunteer-organizations"
+                target="_blank"
+              >
                 {"I'm a volunteer organization"}
               </a>{" "}
               and I want to register with the CRRP

--- a/src/ecrc-frontend/src/components/base/orgValidationText/__snapshots__/OrgValidationText.test.js.snap
+++ b/src/ecrc-frontend/src/components/base/orgValidationText/__snapshots__/OrgValidationText.test.js.snap
@@ -11,6 +11,7 @@ exports[`OrgValidationText Component Matches the snapshot 1`] = `
      
     <a
       href="http://www.bclaws.ca/EPLibraries/bclaws_new/document/ID/freeside/00_96086_01"
+      target="_blank"
     >
       Criminal Records Review Act (CRRA).
     </a>
@@ -35,6 +36,7 @@ exports[`OrgValidationText Component Matches the snapshot 1`] = `
            
           <a
             href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+            target="_blank"
           >
             BC Services Card
           </a>
@@ -86,6 +88,7 @@ exports[`OrgValidationText Component Matches the snapshot 1`] = `
             onChange={[Function]}
             type="text"
           />
+          <br />
           <span
             className="error"
           />
@@ -143,13 +146,16 @@ exports[`OrgValidationText Component Matches the snapshot 1`] = `
         <li>
           <a
             href="volunteer"
+            target="_blank"
           >
             I'm an employee or a volunteer
           </a>
-           and I want to know
+           
+          and I want to know
            
           <a
             href="http://www.rcmp-grc.gc.ca/en/types-criminal-background-checks"
+            target="_blank"
           >
             why I need to apply for a criminal record check
           </a>
@@ -157,6 +163,7 @@ exports[`OrgValidationText Component Matches the snapshot 1`] = `
         <li>
           <a
             href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+            target="_blank"
           >
             I don't have a BC Services Card
           </a>
@@ -164,6 +171,7 @@ exports[`OrgValidationText Component Matches the snapshot 1`] = `
         <li>
           <a
             href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/organization-registration/employee-organization-registration/employee-contact-registration"
+            target="_blank"
           >
             I'm an authorized contact
           </a>
@@ -173,6 +181,7 @@ exports[`OrgValidationText Component Matches the snapshot 1`] = `
         <li>
           <a
             href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/employer-organizations"
+            target="_blank"
           >
             I'm an employer organization
           </a>
@@ -182,6 +191,7 @@ exports[`OrgValidationText Component Matches the snapshot 1`] = `
         <li>
           <a
             href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/volunteer-organizations"
+            target="_blank"
           >
             I'm a volunteer organization
           </a>

--- a/src/ecrc-frontend/src/components/base/orgValidationText/__snapshots__/OrgValidationText.test.js.snap
+++ b/src/ecrc-frontend/src/components/base/orgValidationText/__snapshots__/OrgValidationText.test.js.snap
@@ -11,6 +11,7 @@ exports[`OrgValidationText Component Matches the snapshot 1`] = `
      
     <a
       href="http://www.bclaws.ca/EPLibraries/bclaws_new/document/ID/freeside/00_96086_01"
+      rel="noopener noreferrer"
       target="_blank"
     >
       Criminal Records Review Act (CRRA).
@@ -36,6 +37,7 @@ exports[`OrgValidationText Component Matches the snapshot 1`] = `
            
           <a
             href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+            rel="noopener noreferrer"
             target="_blank"
           >
             BC Services Card
@@ -155,6 +157,7 @@ exports[`OrgValidationText Component Matches the snapshot 1`] = `
            
           <a
             href="http://www.rcmp-grc.gc.ca/en/types-criminal-background-checks"
+            rel="noopener noreferrer"
             target="_blank"
           >
             why I need to apply for a criminal record check
@@ -163,6 +166,7 @@ exports[`OrgValidationText Component Matches the snapshot 1`] = `
         <li>
           <a
             href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+            rel="noopener noreferrer"
             target="_blank"
           >
             I don't have a BC Services Card
@@ -171,6 +175,7 @@ exports[`OrgValidationText Component Matches the snapshot 1`] = `
         <li>
           <a
             href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/organization-registration/employee-organization-registration/employee-contact-registration"
+            rel="noopener noreferrer"
             target="_blank"
           >
             I'm an authorized contact
@@ -181,6 +186,7 @@ exports[`OrgValidationText Component Matches the snapshot 1`] = `
         <li>
           <a
             href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/employer-organizations"
+            rel="noopener noreferrer"
             target="_blank"
           >
             I'm an employer organization
@@ -191,6 +197,7 @@ exports[`OrgValidationText Component Matches the snapshot 1`] = `
         <li>
           <a
             href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/volunteer-organizations"
+            rel="noopener noreferrer"
             target="_blank"
           >
             I'm a volunteer organization

--- a/src/ecrc-frontend/src/components/base/sideCard/SideCard.js
+++ b/src/ecrc-frontend/src/components/base/sideCard/SideCard.js
@@ -40,7 +40,7 @@ export default function SideCard({
               <div className="submit-content">
                 <span>{content}</span>
                 {image && (
-                  <a href={imageLink} target="_blank">
+                  <a href={imageLink} target="_blank" rel="noopener noreferrer">
                     <img
                       src={image}
                       alt="imagelink"

--- a/src/ecrc-frontend/src/components/base/sideCard/SideCard.js
+++ b/src/ecrc-frontend/src/components/base/sideCard/SideCard.js
@@ -40,7 +40,7 @@ export default function SideCard({
               <div className="submit-content">
                 <span>{content}</span>
                 {image && (
-                  <a href={imageLink}>
+                  <a href={imageLink} target="_blank">
                     <img
                       src={image}
                       alt="imagelink"

--- a/src/ecrc-frontend/src/components/base/termsOfUse/TermsOfUse.js
+++ b/src/ecrc-frontend/src/components/base/termsOfUse/TermsOfUse.js
@@ -172,7 +172,7 @@ export default function TermsOfUse({
             disclosed in accordance with the Province’s{" "}
             <a
               href="https://www2.gov.bc.ca/gov/content/home/privacy"
-              target="blank"
+              target="_blank"
               rel="noopener noreferrer"
             >
               Privacy Policy
@@ -208,7 +208,7 @@ export default function TermsOfUse({
             You are required to have a{" "}
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
-              target="blank"
+              target="_blank"
               rel="noopener noreferrer"
             >
               BC Services Card
@@ -220,7 +220,7 @@ export default function TermsOfUse({
             following an external link to the{" "}
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
-              target="blank"
+              target="_blank"
               rel="noopener noreferrer"
             >
               BC Services Card Site
@@ -354,7 +354,7 @@ export default function TermsOfUse({
             In addition to the Province’s general{" "}
             <a
               href="https://www2.gov.bc.ca/gov/content/home/disclaimer"
-              target="blank"
+              target="_blank"
               rel="noopener noreferrer"
             >
               Limitation of Liabilities
@@ -479,7 +479,7 @@ export default function TermsOfUse({
             disclosed in accordance with the Province’s{" "}
             <a
               href="https://www2.gov.bc.ca/gov/content/home/privacy"
-              target="blank"
+              target="_blank"
               rel="noopener noreferrer"
             >
               Privacy Policy
@@ -515,7 +515,7 @@ export default function TermsOfUse({
             You are required to have a{" "}
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
-              target="blank"
+              target="_blank"
               rel="noopener noreferrer"
             >
               BC Services Card
@@ -527,7 +527,7 @@ export default function TermsOfUse({
             following an external link to the{" "}
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
-              target="blank"
+              target="_blank"
               rel="noopener noreferrer"
             >
               BC Services Card Site
@@ -661,7 +661,7 @@ export default function TermsOfUse({
             In addition to the Province’s general{" "}
             <a
               href="https://www2.gov.bc.ca/gov/content/home/disclaimer"
-              target="blank"
+              target="_blank"
               rel="noopener noreferrer"
             >
               Limitation of Liabilities

--- a/src/ecrc-frontend/src/components/base/termsOfUse/__snapshots__/TermsOfUse.test.js.snap
+++ b/src/ecrc-frontend/src/components/base/termsOfUse/__snapshots__/TermsOfUse.test.js.snap
@@ -136,7 +136,7 @@ exports[`TermsOfUse Component Matches the snapshot 1`] = `
         <a
           href="https://www2.gov.bc.ca/gov/content/home/privacy"
           rel="noopener noreferrer"
-          target="blank"
+          target="_blank"
         >
           Privacy Policy
         </a>
@@ -164,7 +164,7 @@ exports[`TermsOfUse Component Matches the snapshot 1`] = `
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
           rel="noopener noreferrer"
-          target="blank"
+          target="_blank"
         >
           BC Services Card
         </a>
@@ -177,7 +177,7 @@ exports[`TermsOfUse Component Matches the snapshot 1`] = `
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
           rel="noopener noreferrer"
-          target="blank"
+          target="_blank"
         >
           BC Services Card Site
         </a>
@@ -303,7 +303,7 @@ exports[`TermsOfUse Component Matches the snapshot 1`] = `
         <a
           href="https://www2.gov.bc.ca/gov/content/home/disclaimer"
           rel="noopener noreferrer"
-          target="blank"
+          target="_blank"
         >
           Limitation of Liabilities
         </a>
@@ -393,7 +393,7 @@ exports[`TermsOfUse Component Matches the snapshot 1`] = `
         <a
           href="https://www2.gov.bc.ca/gov/content/home/privacy"
           rel="noopener noreferrer"
-          target="blank"
+          target="_blank"
         >
           Privacy Policy
         </a>
@@ -421,7 +421,7 @@ exports[`TermsOfUse Component Matches the snapshot 1`] = `
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
           rel="noopener noreferrer"
-          target="blank"
+          target="_blank"
         >
           BC Services Card
         </a>
@@ -434,7 +434,7 @@ exports[`TermsOfUse Component Matches the snapshot 1`] = `
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
           rel="noopener noreferrer"
-          target="blank"
+          target="_blank"
         >
           BC Services Card Site
         </a>
@@ -560,7 +560,7 @@ exports[`TermsOfUse Component Matches the snapshot 1`] = `
         <a
           href="https://www2.gov.bc.ca/gov/content/home/disclaimer"
           rel="noopener noreferrer"
-          target="blank"
+          target="_blank"
         >
           Limitation of Liabilities
         </a>

--- a/src/ecrc-frontend/src/components/base/textInput/TextInput.js
+++ b/src/ecrc-frontend/src/components/base/textInput/TextInput.js
@@ -60,6 +60,7 @@ export const TextInput = ({
           readOnly
           onChange={onChange}
         />
+        <br />
         <span className="error">{errorMsg}</span>
       </div>
     );
@@ -92,6 +93,7 @@ export const TextInput = ({
         placeholder={placeholder}
         onChange={event => onChange(event.target.value)}
       />
+      <br />
       <span className="error">{errorMsg}</span>
     </div>
   );

--- a/src/ecrc-frontend/src/components/base/textInput/__snapshots__/TextInput.test.js.snap
+++ b/src/ecrc-frontend/src/components/base/textInput/__snapshots__/TextInput.test.js.snap
@@ -24,6 +24,7 @@ exports[`TextInput Component Matches the snapshot 1`] = `
     onChange={[Function]}
     type="text"
   />
+  <br />
   <span
     className="error"
   />

--- a/src/ecrc-frontend/src/components/composite/fullName/__snapshots__/FullName.test.js.snap
+++ b/src/ecrc-frontend/src/components/composite/fullName/__snapshots__/FullName.test.js.snap
@@ -35,6 +35,7 @@ exports[`FullName Component Matches the snapshot 1`] = `
           readOnly={true}
           type="text"
         />
+        <br />
         <span
           className="error"
         />
@@ -65,6 +66,7 @@ exports[`FullName Component Matches the snapshot 1`] = `
           readOnly={true}
           type="text"
         />
+        <br />
         <span
           className="error"
         />
@@ -95,6 +97,7 @@ exports[`FullName Component Matches the snapshot 1`] = `
           readOnly={true}
           type="text"
         />
+        <br />
         <span
           className="error"
         />

--- a/src/ecrc-frontend/src/components/composite/menu/__snapshots__/Menu.test.js.snap
+++ b/src/ecrc-frontend/src/components/composite/menu/__snapshots__/Menu.test.js.snap
@@ -35,7 +35,8 @@ exports[`Menu Component Matches the snapshot of populated menu 1`] = `
         >
           <a
             href="/"
-            target="blank"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Home
           </a>
@@ -45,7 +46,8 @@ exports[`Menu Component Matches the snapshot of populated menu 1`] = `
         >
           <a
             href="/somewhere"
-            target="blank"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Somewhere
           </a>
@@ -55,7 +57,8 @@ exports[`Menu Component Matches the snapshot of populated menu 1`] = `
         >
           <a
             href="/somewhereelse"
-            target="blank"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Somewhere else
           </a>
@@ -65,7 +68,8 @@ exports[`Menu Component Matches the snapshot of populated menu 1`] = `
         >
           <a
             href="/here"
-            target="blank"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Somewhere with a long name for no reason
           </a>

--- a/src/ecrc-frontend/src/components/composite/sideCards/SideCards.js
+++ b/src/ecrc-frontend/src/components/composite/sideCards/SideCards.js
@@ -88,7 +88,8 @@ export default function SideCards({ type, sideCardLinks }) {
       <div key="bcscLearnMore">
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
-          target="blank"
+          target="_blank"
+          rel="noopener noreferrer"
         >
           <div className="side-card-link">
             Learn more about the BC Services Card.
@@ -103,7 +104,8 @@ export default function SideCards({ type, sideCardLinks }) {
       <div key="bcscEligibilityLink">
         <a
           href="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/eligibility-and-enrolment/are-you-eligible"
-          target="blank"
+          target="_blank"
+          rel="noopener noreferrer"
         >
           <div className="side-card-link">
             Learn more about BC Services Card eligibility.
@@ -211,7 +213,8 @@ export default function SideCards({ type, sideCardLinks }) {
       <div key="withoutBCSCBottom">
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
-          target="blank"
+          target="_blank"
+          rel="noopener noreferrer"
         >
           <div className="side-card-link">
             Learn more about how to apply for a criminal record check offline.
@@ -250,7 +253,8 @@ export default function SideCards({ type, sideCardLinks }) {
         key="serviceBC"
         className="link"
         href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
-        target="blank"
+        target="_blank"
+        rel="noopener noreferrer"
       >
         Service BC
       </a>,
@@ -259,7 +263,8 @@ export default function SideCards({ type, sideCardLinks }) {
         key="icbc"
         className="link"
         href="https://www.icbc.com/Pages/default.aspx"
-        target="blank"
+        target="_blank"
+        rel="noopener noreferrer"
       >
         ICBC
       </a>,
@@ -268,7 +273,8 @@ export default function SideCards({ type, sideCardLinks }) {
         key="addressChangeBC"
         className="link"
         href="https://www.addresschange.gov.bc.ca/"
-        target="blank"
+        target="_blank"
+        rel="noopener noreferrer"
       >
         AddressChangeBC
       </a>,

--- a/src/ecrc-frontend/src/components/composite/sideCards/__snapshots__/SideCards.test.js.snap
+++ b/src/ecrc-frontend/src/components/composite/sideCards/__snapshots__/SideCards.test.js.snap
@@ -129,7 +129,8 @@ exports[`SideCards Component AccessCode sidecard 2`] = `
               >
                 <a
                   href="/"
-                  target="blank"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
                   Home
                 </a>
@@ -139,7 +140,8 @@ exports[`SideCards Component AccessCode sidecard 2`] = `
               >
                 <a
                   href="/somewhere"
-                  target="blank"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
                   Somewhere
                 </a>
@@ -149,7 +151,8 @@ exports[`SideCards Component AccessCode sidecard 2`] = `
               >
                 <a
                   href="/somewhereelse"
-                  target="blank"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
                   Somewhere else
                 </a>
@@ -159,7 +162,8 @@ exports[`SideCards Component AccessCode sidecard 2`] = `
               >
                 <a
                   href="/here"
-                  target="blank"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
                   Somewhere with a long name for no reason
                 </a>
@@ -248,7 +252,8 @@ exports[`SideCards Component BcServices sidecard 1`] = `
               <div>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
-                  target="blank"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
                   <div
                     className="side-card-link"
@@ -266,7 +271,8 @@ exports[`SideCards Component BcServices sidecard 1`] = `
               <div>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/eligibility-and-enrolment/are-you-eligible"
-                  target="blank"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
                   <div
                     className="side-card-link"

--- a/src/ecrc-frontend/src/components/composite/simpleForm/__snapshots__/SimpleForm.test.js.snap
+++ b/src/ecrc-frontend/src/components/composite/simpleForm/__snapshots__/SimpleForm.test.js.snap
@@ -33,6 +33,7 @@ exports[`SimpleForm Component Matches the snapshot 1`] = `
           onChange={[Function]}
           type="text"
         />
+        <br />
         <span
           className="error"
         />
@@ -66,6 +67,7 @@ exports[`SimpleForm Component Matches the snapshot 1`] = `
           onChange={[Function]}
           type="text"
         />
+        <br />
         <span
           className="error"
         />

--- a/src/ecrc-frontend/src/components/page/applicationForm/ApplicationForm.js
+++ b/src/ecrc-frontend/src/components/page/applicationForm/ApplicationForm.js
@@ -712,13 +712,20 @@ export default function ApplicationForm({
             Entering your mailing address in this application will not update
             your BC Services Card Address. To update your BC Services Card
             information you must contact&nbsp;
-            <a href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc">
+            <a
+              href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
+              target="_blank"
+            >
               Service BC
             </a>
             ,&nbsp;
-            <a href="https://www.icbc.com/Pages/default.aspx">ICBC</a>
+            <a href="https://www.icbc.com/Pages/default.aspx" target="_blank">
+              ICBC
+            </a>
             &nbsp;or&nbsp;
-            <a href="https://www.addresschange.gov.bc.ca/">AddressChangeBC</a>
+            <a href="https://www.addresschange.gov.bc.ca/" target="_blank">
+              AddressChangeBC
+            </a>
           </section>
           <br />
           <div className="buttons">

--- a/src/ecrc-frontend/src/components/page/applicationForm/ApplicationForm.js
+++ b/src/ecrc-frontend/src/components/page/applicationForm/ApplicationForm.js
@@ -715,15 +715,24 @@ export default function ApplicationForm({
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
               target="_blank"
+              rel="noopener noreferrer"
             >
               Service BC
             </a>
             ,&nbsp;
-            <a href="https://www.icbc.com/Pages/default.aspx" target="_blank">
+            <a
+              href="https://www.icbc.com/Pages/default.aspx"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               ICBC
             </a>
             &nbsp;or&nbsp;
-            <a href="https://www.addresschange.gov.bc.ca/" target="_blank">
+            <a
+              href="https://www.addresschange.gov.bc.ca/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               AddressChangeBC
             </a>
           </section>

--- a/src/ecrc-frontend/src/components/page/applicationForm/__snapshots__/ApplicationForm.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/applicationForm/__snapshots__/ApplicationForm.test.js.snap
@@ -102,6 +102,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value="Robert"
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -130,6 +131,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value="Norman"
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -158,6 +160,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value="Ross"
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -205,6 +208,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value=""
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -232,6 +236,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value=""
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -259,6 +264,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value=""
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -310,6 +316,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value=""
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -338,6 +345,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value="1942-10-29"
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -366,6 +374,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value="Male"
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -395,6 +404,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value=""
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -431,6 +441,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value=""
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -467,6 +478,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value=""
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -513,6 +525,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value=""
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -549,6 +562,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value=""
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -602,6 +616,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value="123 Somewhere"
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -630,6 +645,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value="Here"
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -658,6 +674,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value="British Columbia"
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -686,6 +703,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value="V9V 9V9"
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -714,6 +732,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value="Canada"
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -790,6 +809,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value="123 Somewhere"
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -824,6 +844,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value="Here"
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -902,6 +923,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value="V9V 9V9"
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -930,6 +952,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                   type="text"
                   value="Canada"
                 />
+                <br />
                 <span
                   class="error"
                 />
@@ -942,18 +965,21 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
           Entering your mailing address in this application will not update your BC Services Card Address. To update your BC Services Card information you must contact 
           <a
             href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
+            target="_blank"
           >
             Service BC
           </a>
           , 
           <a
             href="https://www.icbc.com/Pages/default.aspx"
+            target="_blank"
           >
             ICBC
           </a>
            or 
           <a
             href="https://www.addresschange.gov.bc.ca/"
+            target="_blank"
           >
             AddressChangeBC
           </a>

--- a/src/ecrc-frontend/src/components/page/applicationForm/__snapshots__/ApplicationForm.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/applicationForm/__snapshots__/ApplicationForm.test.js.snap
@@ -965,6 +965,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
           Entering your mailing address in this application will not update your BC Services Card Address. To update your BC Services Card information you must contact 
           <a
             href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
+            rel="noopener noreferrer"
             target="_blank"
           >
             Service BC
@@ -972,6 +973,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
           , 
           <a
             href="https://www.icbc.com/Pages/default.aspx"
+            rel="noopener noreferrer"
             target="_blank"
           >
             ICBC
@@ -979,6 +981,7 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
            or 
           <a
             href="https://www.addresschange.gov.bc.ca/"
+            rel="noopener noreferrer"
             target="_blank"
           >
             AddressChangeBC
@@ -1098,7 +1101,8 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                       <a
                         class="link"
                         href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         Service BC
                       </a>
@@ -1106,7 +1110,8 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                       <a
                         class="link"
                         href="https://www.icbc.com/Pages/default.aspx"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         ICBC
                       </a>
@@ -1114,7 +1119,8 @@ exports[`ApplicationForm Component Matches the snapshot 1`] = `
                       <a
                         class="link"
                         href="https://www.addresschange.gov.bc.ca/"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         AddressChangeBC
                       </a>

--- a/src/ecrc-frontend/src/components/page/bcscRedirect/BcscRedirect.js
+++ b/src/ecrc-frontend/src/components/page/bcscRedirect/BcscRedirect.js
@@ -83,14 +83,20 @@ export default function BcscRedirect({ page: { header, saveOrg, setError } }) {
           <br />
           <p>
             To apply for a criminal record check online, you must use your{" "}
-            <a href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card">
+            <a
+              href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+              target="_blank"
+            >
               BC Services Card
             </a>{" "}
             Account. Only cards <b>with a photo</b> are accepted. If it&apos;s
             your first time using your BC Services Card to access an online
             service, you need to set up your account for use online. Completing
             a one-time security check to{" "}
-            <a href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card">
+            <a
+              href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+              target="_blank"
+            >
               verify your identity
             </a>
             .
@@ -114,7 +120,7 @@ export default function BcscRedirect({ page: { header, saveOrg, setError } }) {
           </div>
 
           <div style={{ marginTop: "40px" }}>
-            <a href="/criminalrecordcheck/transition">
+            <a href="/criminalrecordcheck/transition" target="_blank">
               I do not have a BC Services Card, or I have non-photo BC Services
               Card
             </a>

--- a/src/ecrc-frontend/src/components/page/bcscRedirect/BcscRedirect.js
+++ b/src/ecrc-frontend/src/components/page/bcscRedirect/BcscRedirect.js
@@ -86,6 +86,7 @@ export default function BcscRedirect({ page: { header, saveOrg, setError } }) {
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
               target="_blank"
+              rel="noopener noreferrer"
             >
               BC Services Card
             </a>{" "}
@@ -96,6 +97,7 @@ export default function BcscRedirect({ page: { header, saveOrg, setError } }) {
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
               target="_blank"
+              rel="noopener noreferrer"
             >
               verify your identity
             </a>

--- a/src/ecrc-frontend/src/components/page/bcscRedirect/__snapshots__/BcscRedirect.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/bcscRedirect/__snapshots__/BcscRedirect.test.js.snap
@@ -71,6 +71,7 @@ exports[`BcscRedirect Page Component Matches the snapshot 1`] = `
           To apply for a criminal record check online, you must use your 
           <a
             href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+            target="_blank"
           >
             BC Services Card
           </a>
@@ -81,6 +82,7 @@ exports[`BcscRedirect Page Component Matches the snapshot 1`] = `
            are accepted. If it's your first time using your BC Services Card to access an online service, you need to set up your account for use online. Completing a one-time security check to 
           <a
             href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+            target="_blank"
           >
             verify your identity
           </a>
@@ -131,6 +133,7 @@ exports[`BcscRedirect Page Component Matches the snapshot 1`] = `
         >
           <a
             href="/criminalrecordcheck/transition"
+            target="_blank"
           >
             I do not have a BC Services Card, or I have non-photo BC Services Card
           </a>

--- a/src/ecrc-frontend/src/components/page/bcscRedirect/__snapshots__/BcscRedirect.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/bcscRedirect/__snapshots__/BcscRedirect.test.js.snap
@@ -71,6 +71,7 @@ exports[`BcscRedirect Page Component Matches the snapshot 1`] = `
           To apply for a criminal record check online, you must use your 
           <a
             href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+            rel="noopener noreferrer"
             target="_blank"
           >
             BC Services Card
@@ -82,6 +83,7 @@ exports[`BcscRedirect Page Component Matches the snapshot 1`] = `
            are accepted. If it's your first time using your BC Services Card to access an online service, you need to set up your account for use online. Completing a one-time security check to 
           <a
             href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
+            rel="noopener noreferrer"
             target="_blank"
           >
             verify your identity
@@ -203,7 +205,8 @@ exports[`BcscRedirect Page Component Matches the snapshot 1`] = `
                       <div>
                         <a
                           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
-                          target="blank"
+                          rel="noopener noreferrer"
+                          target="_blank"
                         >
                           <div
                             class="side-card-link"
@@ -221,7 +224,8 @@ exports[`BcscRedirect Page Component Matches the snapshot 1`] = `
                       <div>
                         <a
                           href="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/eligibility-and-enrolment/are-you-eligible"
-                          target="blank"
+                          rel="noopener noreferrer"
+                          target="_blank"
                         >
                           <div
                             class="side-card-link"

--- a/src/ecrc-frontend/src/components/page/informationreview/__snapshots__/InformationReview.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/informationreview/__snapshots__/InformationReview.test.js.snap
@@ -540,7 +540,8 @@ exports[`InformationReview Component Matches the snapshot 1`] = `
                     <a
                       className="link"
                       href="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/servicebc"
-                      target="blank"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       Service BC
                     </a>
@@ -548,7 +549,8 @@ exports[`InformationReview Component Matches the snapshot 1`] = `
                     <a
                       className="link"
                       href="https://www.icbc.com/Pages/default.aspx"
-                      target="blank"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       ICBC
                     </a>
@@ -556,7 +558,8 @@ exports[`InformationReview Component Matches the snapshot 1`] = `
                     <a
                       className="link"
                       href="https://www.addresschange.gov.bc.ca/"
-                      target="blank"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       AddressChangeBC
                     </a>

--- a/src/ecrc-frontend/src/components/page/orgValidation/OrgValidation.js
+++ b/src/ecrc-frontend/src/components/page/orgValidation/OrgValidation.js
@@ -40,6 +40,11 @@ export default function OrgValidation({
   };
 
   const orgValidation = () => {
+    if (!orgTicketNumber) {
+      setOrgError("An access code is required to continue.");
+      return false;
+    }
+
     setLoading(true);
     const uuid = sessionStorage.getItem("uuid");
     const payload = { authorities: ["ROLE"] };
@@ -87,6 +92,8 @@ export default function OrgValidation({
           setToError(true);
         }
       });
+
+    return true;
   };
 
   const textInput = {

--- a/src/ecrc-frontend/src/components/page/orgValidation/__snapshots__/OrgValidation.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/orgValidation/__snapshots__/OrgValidation.test.js.snap
@@ -72,6 +72,7 @@ exports[`OrgValidation Component Matches the snapshot 1`] = `
            
           <a
             href="http://www.bclaws.ca/EPLibraries/bclaws_new/document/ID/freeside/00_96086_01"
+            target="_blank"
           >
             Criminal Records Review Act (CRRA).
           </a>
@@ -96,6 +97,7 @@ exports[`OrgValidation Component Matches the snapshot 1`] = `
                  
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                  target="_blank"
                 >
                   BC Services Card
                 </a>
@@ -127,6 +129,7 @@ exports[`OrgValidation Component Matches the snapshot 1`] = `
                   onChange={[Function]}
                   type="text"
                 />
+                <br />
                 <span
                   className="error"
                 >
@@ -187,13 +190,16 @@ exports[`OrgValidation Component Matches the snapshot 1`] = `
               <li>
                 <a
                   href="volunteer"
+                  target="_blank"
                 >
                   I'm an employee or a volunteer
                 </a>
-                 and I want to know
+                 
+                and I want to know
                  
                 <a
                   href="http://www.rcmp-grc.gc.ca/en/types-criminal-background-checks"
+                  target="_blank"
                 >
                   why I need to apply for a criminal record check
                 </a>
@@ -201,6 +207,7 @@ exports[`OrgValidation Component Matches the snapshot 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                  target="_blank"
                 >
                   I don't have a BC Services Card
                 </a>
@@ -208,6 +215,7 @@ exports[`OrgValidation Component Matches the snapshot 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/organization-registration/employee-organization-registration/employee-contact-registration"
+                  target="_blank"
                 >
                   I'm an authorized contact
                 </a>
@@ -217,6 +225,7 @@ exports[`OrgValidation Component Matches the snapshot 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/employer-organizations"
+                  target="_blank"
                 >
                   I'm an employer organization
                 </a>
@@ -226,6 +235,7 @@ exports[`OrgValidation Component Matches the snapshot 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/volunteer-organizations"
+                  target="_blank"
                 >
                   I'm a volunteer organization
                 </a>

--- a/src/ecrc-frontend/src/components/page/orgValidation/__snapshots__/OrgValidation.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/orgValidation/__snapshots__/OrgValidation.test.js.snap
@@ -72,6 +72,7 @@ exports[`OrgValidation Component Matches the snapshot 1`] = `
            
           <a
             href="http://www.bclaws.ca/EPLibraries/bclaws_new/document/ID/freeside/00_96086_01"
+            rel="noopener noreferrer"
             target="_blank"
           >
             Criminal Records Review Act (CRRA).
@@ -97,6 +98,7 @@ exports[`OrgValidation Component Matches the snapshot 1`] = `
                  
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   BC Services Card
@@ -199,6 +201,7 @@ exports[`OrgValidation Component Matches the snapshot 1`] = `
                  
                 <a
                   href="http://www.rcmp-grc.gc.ca/en/types-criminal-background-checks"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   why I need to apply for a criminal record check
@@ -207,6 +210,7 @@ exports[`OrgValidation Component Matches the snapshot 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   I don't have a BC Services Card
@@ -215,6 +219,7 @@ exports[`OrgValidation Component Matches the snapshot 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/organization-registration/employee-organization-registration/employee-contact-registration"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   I'm an authorized contact
@@ -225,6 +230,7 @@ exports[`OrgValidation Component Matches the snapshot 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/employer-organizations"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   I'm an employer organization
@@ -235,6 +241,7 @@ exports[`OrgValidation Component Matches the snapshot 1`] = `
               <li>
                 <a
                   href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/volunteer-organizations"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   I'm a volunteer organization

--- a/src/ecrc-frontend/src/components/page/orgVerification/OrgVerification.js
+++ b/src/ecrc-frontend/src/components/page/orgVerification/OrgVerification.js
@@ -26,7 +26,6 @@ export default function OrgVerification({ page: { header, org, setError } }) {
 
     if (!isAuthenticated() || !org.orgNm) {
       setToHome(true);
-      console.log("Test server");
     }
 
     window.scrollTo(0, 0);

--- a/src/ecrc-frontend/src/components/page/orgVerification/OrgVerification.js
+++ b/src/ecrc-frontend/src/components/page/orgVerification/OrgVerification.js
@@ -168,7 +168,8 @@ export default function OrgVerification({ page: { header, org, setError } }) {
                 initiate the process at the{" "}
                 <a
                   href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
-                  target="blank"
+                  target="_blank"
+                  rel="noopener noreferrer"
                 >
                   BC Service Card website
                 </a>

--- a/src/ecrc-frontend/src/components/page/orgVerification/__snapshots__/OrgVerification.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/orgVerification/__snapshots__/OrgVerification.test.js.snap
@@ -169,7 +169,8 @@ Canada
              
             <a
               href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
-              target="blank"
+              rel="noopener noreferrer"
+              target="_blank"
             >
               BC Service Card website
             </a>
@@ -409,7 +410,8 @@ Canada
                     >
                       <a
                         href="/tbd"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         I'm an employee or volunteer
                       </a>
@@ -419,7 +421,8 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/electronic-identity-verification-eiv"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         Electronic Identity Verification (EIV)
                       </a>
@@ -429,7 +432,8 @@ Canada
                     >
                       <a
                         href="https://www2.gov.bc.ca/gov/content/safety/crime-prevention/criminal-record-check/results-and-reconsiderations"
-                        target="blank"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         Results and Reconsideration
                       </a>

--- a/src/ecrc-frontend/src/components/page/tou/__snapshots__/TOU.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/tou/__snapshots__/TOU.test.js.snap
@@ -197,7 +197,7 @@ exports[`TermOfUse Page Component Matches the snapshot 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/home/privacy"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 Privacy Policy
               </a>
@@ -225,7 +225,7 @@ exports[`TermOfUse Page Component Matches the snapshot 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 BC Services Card
               </a>
@@ -238,7 +238,7 @@ exports[`TermOfUse Page Component Matches the snapshot 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 BC Services Card Site
               </a>
@@ -364,7 +364,7 @@ exports[`TermOfUse Page Component Matches the snapshot 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/home/disclaimer"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 Limitation of Liabilities
               </a>
@@ -454,7 +454,7 @@ exports[`TermOfUse Page Component Matches the snapshot 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/home/privacy"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 Privacy Policy
               </a>
@@ -482,7 +482,7 @@ exports[`TermOfUse Page Component Matches the snapshot 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/login-with-card"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 BC Services Card
               </a>
@@ -495,7 +495,7 @@ exports[`TermOfUse Page Component Matches the snapshot 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 BC Services Card Site
               </a>
@@ -621,7 +621,7 @@ exports[`TermOfUse Page Component Matches the snapshot 1`] = `
               <a
                 href="https://www2.gov.bc.ca/gov/content/home/disclaimer"
                 rel="noopener noreferrer"
-                target="blank"
+                target="_blank"
               >
                 Limitation of Liabilities
               </a>

--- a/src/ecrc-frontend/src/components/page/transition/Transition.js
+++ b/src/ecrc-frontend/src/components/page/transition/Transition.js
@@ -31,7 +31,10 @@ export default function Transition({
             <p>
               We are transitioning our client organizations currently using
               Equifax for identity verification to a new process through a{" "}
-              <a href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card">
+              <a
+                href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+                target="_blank"
+              >
                 BC Services Card account
               </a>
               {". Your organization hasn't"} been transitioned to the new system

--- a/src/ecrc-frontend/src/components/page/transition/Transition.js
+++ b/src/ecrc-frontend/src/components/page/transition/Transition.js
@@ -34,6 +34,7 @@ export default function Transition({
               <a
                 href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 BC Services Card account
               </a>

--- a/src/ecrc-frontend/src/components/page/transition/__snapshots__/Transition.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/transition/__snapshots__/Transition.test.js.snap
@@ -244,6 +244,7 @@ exports[`Transition Page Component Matches the non-whitelisted snapshot 1`] = `
          
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+          target="_blank"
         >
           BC Services Card account
         </a>

--- a/src/ecrc-frontend/src/components/page/transition/__snapshots__/Transition.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/transition/__snapshots__/Transition.test.js.snap
@@ -244,6 +244,7 @@ exports[`Transition Page Component Matches the non-whitelisted snapshot 1`] = `
          
         <a
           href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card"
+          rel="noopener noreferrer"
           target="_blank"
         >
           BC Services Card account


### PR DESCRIPTION
## Overview

- Make sure if empty access code, we display error instead of taking to transition page
- Links opening in new tab using `_blank` not `blank`

Explanation why:

using `target="blank"` your link will open in a new tab/window. However, there is a subtle difference. Clicking on the link again will reuse the window that was opened the first time instead of opening a new one. Thus, we are using `target="_blank"`

JIRA:

- https://justice.gov.bc.ca/jira/browse/SPDBCSC-492
- https://justice.gov.bc.ca/jira/browse/SPDBCSC-494