### PR TITLE
Fix: BCSC links to open in new tab

### DIFF
--- a/src/ecrc-frontend/src/__snapshots__/storyshots.test.js.snap
+++ b/src/ecrc-frontend/src/__snapshots__/storyshots.test.js.snap
@@ -2805,7 +2805,6 @@ exports[`Storyshots BcscRedirect page Default 1`] = `
       >
         <a
           href="/criminalrecordcheck/transition"
-          target="_blank"
         >
           I do not have a BC Services Card, or I have non-photo BC Services Card
         </a>
@@ -3163,7 +3162,6 @@ exports[`Storyshots BcscRedirect page Mobile 1`] = `
       >
         <a
           href="/criminalrecordcheck/transition"
-          target="_blank"
         >
           I do not have a BC Services Card, or I have non-photo BC Services Card
         </a>

--- a/src/ecrc-frontend/src/components/page/bcscRedirect/BcscRedirect.js
+++ b/src/ecrc-frontend/src/components/page/bcscRedirect/BcscRedirect.js
@@ -122,7 +122,7 @@ export default function BcscRedirect({ page: { header, saveOrg, setError } }) {
           </div>
 
           <div style={{ marginTop: "40px" }}>
-            <a href="/criminalrecordcheck/transition" target="_blank">
+            <a href="/criminalrecordcheck/transition">
               I do not have a BC Services Card, or I have non-photo BC Services
               Card
             </a>

--- a/src/ecrc-frontend/src/components/page/bcscRedirect/__snapshots__/BcscRedirect.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/bcscRedirect/__snapshots__/BcscRedirect.test.js.snap
@@ -135,7 +135,6 @@ exports[`BcscRedirect Page Component Matches the snapshot 1`] = `
         >
           <a
             href="/criminalrecordcheck/transition"
-            target="_blank"
           >
             I do not have a BC Services Card, or I have non-photo BC Services Card
           </a>

--- a/src/ecrc-frontend/src/components/page/success/Success.js
+++ b/src/ecrc-frontend/src/components/page/success/Success.js
@@ -46,7 +46,7 @@ export default function Success({
     ) {
       setToHome(true);
     }
-  }, [paymentInfo.trnApproved]);
+  }, [paymentInfo.trnApproved, orgApplicantRelationship]);
 
   const receiptInfo = [
     { name: "Service Number", value: serviceId },


### PR DESCRIPTION
# Description

Fixed links on bcsc redirect page to open in a new tab, except for "I do not have a BC Services Card, or I have non-photo BC Services Card" which redirects to the transition page. Also fixed warning related to useEffect on success page.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: SPDBCSC-497
