### PR TITLE
Fix: Redirect from bambora after declined card reattempt

### DIFF
--- a/src/ecrc-frontend/src/__snapshots__/storyshots.test.js.snap
+++ b/src/ecrc-frontend/src/__snapshots__/storyshots.test.js.snap
@@ -13488,7 +13488,7 @@ exports[`Storyshots Success page Mobile Payment Failure 1`] = `
           Non-expired date
         </li>
         <li>
-          Availale funds to transfer
+          Available funds to transfer
         </li>
       </ul>
       <p>
@@ -14241,7 +14241,7 @@ exports[`Storyshots Success page PaymentFailure 1`] = `
           Non-expired date
         </li>
         <li>
-          Availale funds to transfer
+          Available funds to transfer
         </li>
       </ul>
       <p>

--- a/src/ecrc-frontend/src/components/base/header/Header.js
+++ b/src/ecrc-frontend/src/components/base/header/Header.js
@@ -19,6 +19,12 @@ export default function Header({ header: { name } }) {
       return false;
     }
 
+    if (history.location.pathname === "/criminalrecordcheck/error") {
+      sessionStorage.clear();
+      history.push("/");
+      return true;
+    }
+
     const wishToRedirect = window.confirm(
       "You are in the middle of completing your eCRC. If you leave, your changes will be lost. Are you sure you would like to leave?"
     );

--- a/src/ecrc-frontend/src/components/page/success/Success.js
+++ b/src/ecrc-frontend/src/components/page/success/Success.js
@@ -113,12 +113,12 @@ export default function Success({
       bcepErrorMsg: paymentInfo.messageText
     };
 
-    // axios
-    //   .post("/ecrc/private/logPaymentFailure", logFailure)
-    //   .then(() => {})
-    //   .catch(error => {
-    //     handleError(error);
-    //   });
+    axios
+      .post("/ecrc/private/logPaymentFailure", logFailure)
+      .then(() => {})
+      .catch(error => {
+        handleError(error);
+      });
   }
 
   // IF Success and not volunteer: UpdateServiceFinancialTxn?

--- a/src/ecrc-frontend/src/components/page/success/Success.js
+++ b/src/ecrc-frontend/src/components/page/success/Success.js
@@ -114,12 +114,12 @@ export default function Success({
       bcepErrorMsg: paymentInfo.messageText
     };
 
-    axios
-      .post("/ecrc/private/logPaymentFailure", logFailure)
-      .then(() => {})
-      .catch(error => {
-        handleError(error);
-      });
+    // axios
+    //   .post("/ecrc/private/logPaymentFailure", logFailure)
+    //   .then(() => {})
+    //   .catch(error => {
+    //     handleError(error);
+    //   });
   }
 
   // IF Success and not volunteer: UpdateServiceFinancialTxn?
@@ -182,6 +182,7 @@ export default function Success({
   };
 
   const retryPayment = () => {
+    sessionStorage.setItem("validExit", true);
     const token = sessionStorage.getItem("jwt");
 
     axios
@@ -207,9 +208,9 @@ export default function Success({
         const createURL = {
           invoiceNumber: newInvoiceId,
           requestGuid: uuid,
-          approvedPage: `${process.env.REACT_APP_FRONTEND_BASE_URL}/ecrc/success`,
-          declinedPage: `${process.env.REACT_APP_FRONTEND_BASE_URL}/ecrc/success`,
-          errorPage: `${process.env.REACT_APP_FRONTEND_BASE_URL}/ecrc/success`,
+          approvedPage: `${process.env.REACT_APP_FRONTEND_BASE_URL}/criminalrecordcheck/success`,
+          declinedPage: `${process.env.REACT_APP_FRONTEND_BASE_URL}/criminalrecordcheck/success`,
+          errorPage: `${process.env.REACT_APP_FRONTEND_BASE_URL}/criminalrecordcheck/success`,
           totalItemsAmount: serviceFeeAmount,
           serviceIdRef1: serviceId,
           partyIdRef2: partyId
@@ -266,7 +267,7 @@ export default function Success({
                 <li>16 digit credit card number</li>
                 <li>3 digit CVD number</li>
                 <li>Non-expired date</li>
-                <li>Availale funds to transfer</li>
+                <li>Available funds to transfer</li>
               </ul>
               <p>
                 <button

--- a/src/ecrc-frontend/src/components/page/success/__snapshots__/Success.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/success/__snapshots__/Success.test.js.snap
@@ -64,7 +64,7 @@ exports[`Success Page Component Matches the FailedPayment snapshot 1`] = `
           Non-expired date
         </li>
         <li>
-          Availale funds to transfer
+          Available funds to transfer
         </li>
       </ul>
       <p>

--- a/src/ecrc-frontend/src/index.js
+++ b/src/ecrc-frontend/src/index.js
@@ -4,7 +4,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import axios from "axios";
 import "@bcgov/bootstrap-theme/dist/css/bootstrap-theme.min.css";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, useHistory } from "react-router-dom";
 import "./index.css";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
@@ -15,12 +15,20 @@ if (process.env.REACT_APP_API_BASE_URL) {
 
 // prevent user from leaving site and losing saved data
 window.addEventListener("beforeunload", e => {
+  const history = useHistory();
   if (sessionStorage.getItem("validExit")) {
     sessionStorage.removeItem("validExit");
     return false;
   }
 
   if (!sessionStorage.getItem("uuid")) return false;
+  if (
+    history.location &&
+    history.location.pathname &&
+    history.location.pathname === "/criminalrecordcheck"
+  ) {
+    return false;
+  }
 
   const confirmationMessage =
     "You are in the middle of completing your eCRC. If you leave, your changes will be lost. Are you sure you would like to leave?";


### PR DESCRIPTION
# Description

Fixed an issue where when retrying a declined payment, the redirect back to the app redirected to a page that did not exist. Also removed some of the pop ups preventing the user from leaving the site in some locations, including the success, error, and org validation pages.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran unit tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: *SPDBCSC-351*
