### PR TITLE
Fix: Button width/stories

### DIFF
--- a/src/ecrc-frontend/src/__snapshots__/storyshots.test.js.snap
+++ b/src/ecrc-frontend/src/__snapshots__/storyshots.test.js.snap
@@ -10299,7 +10299,7 @@ exports[`Storyshots Information Review Display Share Mobile 1`] = `
         </label>
       </section>
       <div
-        className="buttons pt-4"
+        className="buttons info-buttons pt-4"
       >
         <button
           className="btn ecrc_accessary_btn btn"
@@ -10832,7 +10832,7 @@ exports[`Storyshots Information Review Display Share Option 1`] = `
         </label>
       </section>
       <div
-        className="buttons pt-4"
+        className="buttons info-buttons pt-4"
       >
         <button
           className="btn ecrc_accessary_btn btn"
@@ -11365,7 +11365,7 @@ exports[`Storyshots Information Review NonSchedule D Default 1`] = `
         </label>
       </section>
       <div
-        className="buttons pt-4"
+        className="buttons info-buttons pt-4"
       >
         <button
           className="btn ecrc_accessary_btn btn"
@@ -11898,7 +11898,7 @@ exports[`Storyshots Information Review NonSchedule D Mobile 1`] = `
         </label>
       </section>
       <div
-        className="buttons pt-4"
+        className="buttons info-buttons pt-4"
       >
         <button
           className="btn ecrc_accessary_btn btn"
@@ -12439,7 +12439,7 @@ exports[`Storyshots Information Review Schedule D Default 1`] = `
         </label>
       </section>
       <div
-        className="buttons pt-4"
+        className="buttons info-buttons pt-4"
       >
         <button
           className="btn ecrc_accessary_btn btn"
@@ -12980,7 +12980,7 @@ exports[`Storyshots Information Review Schedule D Mobile 1`] = `
         </label>
       </section>
       <div
-        className="buttons pt-4"
+        className="buttons info-buttons pt-4"
       >
         <button
           className="btn ecrc_accessary_btn btn"

--- a/src/ecrc-frontend/src/components/base/button/Button.css
+++ b/src/ecrc-frontend/src/components/base/button/Button.css
@@ -1,6 +1,6 @@
 .ecrc_go_btn {
   background-color: rgb(0, 51, 102);
-  width: 132px;
+  min-width: 132px;
   min-height: 40px;
   color: white;
 }
@@ -12,7 +12,7 @@
 
 .ecrc_accessary_btn {
   color: #003366;
-  width: 150px;
+  min-width: 150px;
   min-height: 40px;
   background-color: white;
   border-width: 1px;
@@ -30,7 +30,7 @@
 
 .ecrc_common_btn {
   color: white;
-  width: 139px;
+  min-width: 139px;
   min-height: 40px;
   font-weight: 700;
   font-style: normal;
@@ -58,7 +58,7 @@
 
 .ecrc_bscs_apply_btn {
   color: white;
-  width: 160px;
+  min-width: 160px;
   min-height: 40px;
   font-weight: 700;
   font-style: normal;

--- a/src/ecrc-frontend/src/components/page/bcscRedirect/BcscRedirect.js
+++ b/src/ecrc-frontend/src/components/page/bcscRedirect/BcscRedirect.js
@@ -46,6 +46,7 @@ export default function BcscRedirect({ page: { header, saveOrg, setError } }) {
         setBcscUrl(res.data);
       })
       .catch(error => {
+        console.log(error);
         setToError(true);
         if (error && error.response && error.response.status) {
           setError({

--- a/src/ecrc-frontend/src/components/page/bcscRedirect/BcscRedirect.js
+++ b/src/ecrc-frontend/src/components/page/bcscRedirect/BcscRedirect.js
@@ -46,7 +46,6 @@ export default function BcscRedirect({ page: { header, saveOrg, setError } }) {
         setBcscUrl(res.data);
       })
       .catch(error => {
-        console.log(error);
         setToError(true);
         if (error && error.response && error.response.status) {
           setError({

--- a/src/ecrc-frontend/src/components/page/bcscRedirect/BcscRedirect.stories.js
+++ b/src/ecrc-frontend/src/components/page/bcscRedirect/BcscRedirect.stories.js
@@ -10,7 +10,7 @@ import { generateJWTToken } from "../../../modules/AuthenticationHelper";
 
 function LoadData(props) {
   const mock = new MockAdapter(axios);
-  const API_REQUEST = "/ecrc/protected/getBCSCUrl?requestGuid=unique123";
+  const API_REQUEST = `/ecrc/protected/getBCSCUrl?requestGuid=unique123&returnUrl=${window.location.origin}/criminalrecordcheck/applicationform`;
 
   mock.onGet(API_REQUEST).reply(200, "bcscurl.com");
 

--- a/src/ecrc-frontend/src/components/page/informationreview/InformationReview.css
+++ b/src/ecrc-frontend/src/components/page/informationreview/InformationReview.css
@@ -1,0 +1,10 @@
+@media (max-width: 575.98px) {
+  .info-buttons {
+    flex-direction: column;
+  }
+
+  .btn {
+    margin-right: 0px;
+    margin-bottom: 5px;
+  }
+}

--- a/src/ecrc-frontend/src/components/page/informationreview/InformationReview.js
+++ b/src/ecrc-frontend/src/components/page/informationreview/InformationReview.js
@@ -101,14 +101,12 @@ export default function InformationReview({
           setShareAvailable(true);
         })
         .catch(error => {
-          console.log(error);
           if (
             error &&
             error.response &&
             error.response.status &&
             error.response.status !== 400
           ) {
-            console.log("Not good");
             setToError(true);
             if (error.response.data && error.response.data.message) {
               setError({

--- a/src/ecrc-frontend/src/components/page/informationreview/InformationReview.js
+++ b/src/ecrc-frontend/src/components/page/informationreview/InformationReview.js
@@ -4,6 +4,7 @@ import { Redirect, useHistory } from "react-router-dom";
 import PropTypes from "prop-types";
 import axios from "axios";
 
+import "./InformationReview.css";
 import Header from "../../base/header/Header";
 import Footer from "../../base/footer/Footer";
 import Table from "../../composite/table/Table";
@@ -425,7 +426,7 @@ export default function InformationReview({
               <br />
             </>
           )}
-          <div className="buttons pt-4">
+          <div className="buttons info-buttons pt-4">
             <Button button={cancelButton} onClick={edit} />
             {shareAvailable && (
               <Button

--- a/src/ecrc-frontend/src/components/page/informationreview/InformationReview.js
+++ b/src/ecrc-frontend/src/components/page/informationreview/InformationReview.js
@@ -101,12 +101,14 @@ export default function InformationReview({
           setShareAvailable(true);
         })
         .catch(error => {
+          console.log(error);
           if (
             error &&
             error.response &&
             error.response.status &&
             error.response.status !== 400
           ) {
+            console.log("Not good");
             setToError(true);
             if (error.response.data && error.response.data.message) {
               setError({

--- a/src/ecrc-frontend/src/components/page/informationreview/InformationReview.stories.js
+++ b/src/ecrc-frontend/src/components/page/informationreview/InformationReview.stories.js
@@ -76,9 +76,9 @@ generateJWTToken(newPayload);
 
 const FailData = props => {
   const mock = new MockAdapter(axios);
-  const API_REQUEST = "/ecrc/private/checkShare?requestGuid=unique123";
+  const API_REQUEST = "/ecrc/private/checkApplicantForPrevCRC";
 
-  mock.onGet(API_REQUEST).reply(404, { message: "No share available." });
+  mock.onPost(API_REQUEST).reply(400, { message: "No share available." });
 
   sessionStorage.setItem("validator", "secret");
   sessionStorage.setItem("uuid", "unique123");

--- a/src/ecrc-frontend/src/components/page/informationreview/__snapshots__/InformationReview.test.js.snap
+++ b/src/ecrc-frontend/src/components/page/informationreview/__snapshots__/InformationReview.test.js.snap
@@ -397,7 +397,7 @@ exports[`InformationReview Component Matches the snapshot for no share 1`] = `
         </label>
       </section>
       <div
-        className="buttons pt-4"
+        className="buttons info-buttons pt-4"
       >
         <button
           className="btn ecrc_accessary_btn btn"
@@ -1055,7 +1055,7 @@ exports[`InformationReview Component Matches the snapshot for share 1`] = `
       </div>
       <br />
       <div
-        className="buttons pt-4"
+        className="buttons info-buttons pt-4"
       >
         <button
           className="btn ecrc_accessary_btn btn"


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- changed buttons to have a min-width, allowing larger buttons to grow as needed
- added css to allow buttons on InfoReview to display in a column on small screen
- fixed stories broken in recent updates

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested locally and in storybook.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
