### PR TITLE
Re-added automatic page transition on transition page

### DIFF
--- a/src/ecrc-frontend/src/components/page/transition/Transition.js
+++ b/src/ecrc-frontend/src/components/page/transition/Transition.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-one-expression-per-line */
-import React from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import Header from "../../base/header/Header";
 import Footer from "../../base/footer/Footer";
@@ -8,6 +8,12 @@ import "./Transition.css";
 export default function Transition({
   page: { header, transitionReason = "bcsc" }
 }) {
+  useEffect(() => {
+    setTimeout(() => {
+      sessionStorage.setItem("validExit", true);
+      window.open("https://justice.gov.bc.ca/eCRC/home.htm", "_self");
+    }, 6000);
+  }, []);
   return (
     <main>
       <Header header={header} />

--- a/src/ecrc-frontend/src/components/page/transition/Transition.test.js
+++ b/src/ecrc-frontend/src/components/page/transition/Transition.test.js
@@ -43,6 +43,23 @@ describe("Transition Page Component", () => {
     expect(nonWhitelistTransition.toJSON()).toMatchSnapshot();
   });
 
+  test("Component waits 6 seconds before automatically redirecting the user", async () => {
+    const history = createMemoryHistory();
+
+    render(
+      <Router history={history}>
+        <Transition page={{ ...page, transitionReason: "notwhitelisted" }} />
+      </Router>
+    );
+
+    await wait(
+      () => {
+        expect(window.open).toHaveBeenCalled();
+      },
+      { timeout: 7000 }
+    );
+  }, 10000);
+
   test("Clicking redirect link opens other app page and does not show a confirmation popup", async () => {
     const history = createMemoryHistory();
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

FIGECRC-294
- Changed transition page to automatically transition to legacy ECRC system after 6 seconds. This is a reversion back to previous functionality that was removed in #413 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Unit tests, manual testing.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
